### PR TITLE
fix: CTS token pollution, kill semantics, and target framework

### DIFF
--- a/src/Fable.Actor/Actor.fs
+++ b/src/Fable.Actor/Actor.fs
@@ -163,19 +163,33 @@ let receive<'Msg> () : ActorOp<'Msg> = {
 
 #else
 
+/// Spawn an actor with an optional external cancellation token.
+/// When the external token is cancelled, the actor's CTS is also cancelled.
+let spawnWithToken (cancellationToken: System.Threading.CancellationToken) (body: Actor<'Msg> -> Async<unit>) : Actor<'Msg> =
+    let cts = new System.Threading.CancellationTokenSource()
+    cancellationToken.Register(fun () -> cts.Cancel()) |> ignore
+    let mutable inbox: Actor<'Msg> option = None
+
+    let mb =
+        MailboxProcessor.Start(fun mb ->
+            let actor = { Mb = mb; Cts = cts }
+            inbox <- Some actor
+            body actor)
+
+    match inbox with
+    | Some a -> a
+    | None -> { Mb = mb; Cts = cts }
+
 /// Spawn an actor. Body receives inbox (self-reference) for Receive/Post.
 let spawn (body: Actor<'Msg> -> Async<unit>) : Actor<'Msg> =
     let cts = new System.Threading.CancellationTokenSource()
     let mutable inbox: Actor<'Msg> option = None
 
     let mb =
-        MailboxProcessor.Start(
-            (fun mb ->
-                let actor = { Mb = mb; Cts = cts }
-                inbox <- Some actor
-                body actor),
-            cts.Token
-        )
+        MailboxProcessor.Start(fun mb ->
+            let actor = { Mb = mb; Cts = cts }
+            inbox <- Some actor
+            body actor)
 
     match inbox with
     | Some a -> a
@@ -187,31 +201,30 @@ let spawnLinked (parent: Actor<'ParentMsg>) (body: Actor<'Msg> -> Async<unit>) :
     let mutable inbox: Actor<'Msg> option = None
 
     let mb =
-        MailboxProcessor.Start(
-            (fun mb ->
-                let actor = { Mb = mb; Cts = cts }
-                inbox <- Some actor
+        MailboxProcessor.Start(fun mb ->
+            let actor = { Mb = mb; Cts = cts }
+            inbox <- Some actor
 
-                async {
-                    try
-                        do! body actor
-                    with ex ->
-                        parent.Post(
-                            unbox {
-                                Pid = box mb
-                                Reason = box ex
-                            }
-                        )
-                }),
-            cts.Token
-        )
+            async {
+                try
+                    do! body actor
+                with ex ->
+                    parent.Post(
+                        unbox {
+                            Pid = box mb
+                            Reason = box ex
+                        }
+                    )
+            })
 
     match inbox with
     | Some a -> a
     | None -> { Mb = mb; Cts = cts }
 
-/// Kill an actor — cancels its token, stopping message delivery.
-let kill (actor: Actor<'Msg>) : unit = actor.Cts.Cancel()
+/// Kill an actor — cancels its token and disposes the MailboxProcessor.
+let kill (actor: Actor<'Msg>) : unit =
+    actor.Cts.Cancel()
+    (actor.Mb :> System.IDisposable).Dispose()
 
 /// Enable supervision (stub on non-BEAM).
 let trapExits () : unit = ()

--- a/src/Fable.Actor/Fable.Actor.fsproj
+++ b/src/Fable.Actor/Fable.Actor.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Author>Dag Brattli</Author>
     <Copyright>Dag Brattli</Copyright>


### PR DESCRIPTION
## Summary
- **CTS token pollution**: Remove `cts.Token` from `MailboxProcessor.Start` in `spawn` and `spawnLinked` — prevents the actor's CTS from becoming the ambient cancellation token for all async operations inside the body, which caused subtle bugs when code used separate CancellationTokens
- **kill semantics**: Dispose the MailboxProcessor after cancelling the CTS to ensure clean shutdown (since the token is no longer passed to Start)
- **spawnWithToken**: New function for external cancellation coordination (e.g., debounce operator)
- **Target framework**: Switch from `net10.0` to `netstandard2.0` for broader compatibility with Fable and consumer projects

## Test plan
- [x] `dotnet build` passes
- [ ] Verify AsyncRx works with actor-based composition
- [ ] Verify kill properly stops actors

🤖 Generated with [Claude Code](https://claude.com/claude-code)