### PR TITLE
feat: Tuple-based call/reply API with cast for fire-and-forget

### DIFF
--- a/examples/interop/src/InteropExample.fs
+++ b/examples/interop/src/InteropExample.fs
@@ -27,13 +27,13 @@ let private rawSend (pid: obj) (msg: obj) : unit = nativeOnly
 
 type DagMsg =
     | HelloFrom of string
-    | AskName of ReplyChannel<string>
+    | AskName
 
 // --- Dag: the F# actor ---
 
 /// Start Dag. He keeps Joe's raw pid as state so he can reply.
-let startDag (joePid: obj) : Actor<DagMsg> =
-    Actor.start joePid (fun joePid msg ->
+let startDag (joePid: obj) : Actor<DagMsg * ReplyChannel<string>> =
+    Actor.start joePid (fun joePid (msg, rc) ->
         match msg with
         | HelloFrom name ->
             printfmt "  [Dag/F#]     Received hello from ~s~n" [ name ]
@@ -41,7 +41,7 @@ let startDag (joePid: obj) : Actor<DagMsg> =
             rawSend joePid "Hei Joe! Dag her. Hyggelig å møte deg!"
             Continue joePid
 
-        | AskName rc ->
+        | AskName ->
             printfmt "  [Dag/F#]     Someone asked my name~n" []
             rc.Reply "Dag Brattli"
             Continue joePid)

--- a/src/Fable.Actor/Actor.fs
+++ b/src/Fable.Actor/Actor.fs
@@ -126,48 +126,27 @@ let trapExits () : unit = platform.trapExits ()
 let formatReason (reason: obj) : string = platform.formatReason reason
 
 /// Send a message and await a reply (inside actor { }).
-let call (actor: Actor<'TargetMsg>) (msgFactory: ReplyChannel<'Reply> -> 'TargetMsg) : ActorOp<'Reply> = {
+let call (actor: Actor<'Msg * ReplyChannel<'Reply>>) (msg: 'Msg) : ActorOp<'Reply> = {
     Run = fun cont ->
         let ref = platform.makeRef ()
         let callerPid = platform.selfPid ()
         let rc: ReplyChannel<'Reply> = { Reply = fun reply -> platform.sendReply (callerPid, ref, reply) }
-        platform.sendMsg (actor.Pid, box (msgFactory rc))
+        platform.sendMsg (actor.Pid, box (msg, rc))
         cont (unbox (platform.recvReply ref))
 }
 
 /// Send a message and await a reply with a timeout in milliseconds.
 /// Raises TimeoutException if no reply is received within the timeout.
-let callWithTimeout (timeout: int) (actor: Actor<'TargetMsg>) (msgFactory: ReplyChannel<'Reply> -> 'TargetMsg) : ActorOp<'Reply> = {
+let callWithTimeout (timeout: int) (actor: Actor<'Msg * ReplyChannel<'Reply>>) (msg: 'Msg) : ActorOp<'Reply> = {
     Run = fun cont ->
         let ref = platform.makeRef ()
         let callerPid = platform.selfPid ()
         let rc: ReplyChannel<'Reply> = { Reply = fun reply -> platform.sendReply (callerPid, ref, reply) }
-        platform.sendMsg (actor.Pid, box (msgFactory rc))
+        platform.sendMsg (actor.Pid, box (msg, rc))
 
         match platform.recvReplyWithTimeout (ref, timeout) with
         | Some reply -> cont (unbox<'Reply> reply)
         | None -> raise (System.TimeoutException("Actor call timed out"))
-}
-
-/// Send a message and await a reply (non-blocking, inside actor { }).
-let callAsync<'Reply, 'Msg> (actor: Actor<'Msg>) (msg: 'Msg) : ActorOp<'Reply> = {
-    Run = fun cont ->
-        let ref = platform.makeRef ()
-        let callerPid = platform.selfPid ()
-        platform.sendMsg (actor.Pid, box (callerPid, ref, box msg))
-        let reply = platform.recvReply ref
-        cont (unbox<'Reply> reply)
-}
-
-/// Receive a message with a reply channel (inside actor { }).
-let receiveAndReply<'Msg, 'Reply> () : ActorOp<'Msg * ReplyChannel<'Reply>> = {
-    Run = fun cont ->
-        platform.receive (fun raw ->
-            let (callerPid, ref, msgRaw) = unbox<obj * obj * obj> raw
-            let rc: ReplyChannel<'Reply> = {
-                Reply = fun reply -> platform.sendReply (callerPid, ref, box reply)
-            }
-            cont (unbox<'Msg> msgRaw, rc))
 }
 
 /// Receive next message (free function, uses platform receive).
@@ -244,21 +223,21 @@ let kill (actor: Actor<'Msg>) : unit =
 let trapExits () : unit = ()
 
 /// Send a message and await a reply (inside actor { }).
-let call (target: Actor<'TargetMsg>) (msgFactory: ReplyChannel<'Reply> -> 'TargetMsg) : ActorOp<'Reply> =
+let call (target: Actor<'Msg * ReplyChannel<'Reply>>) (msg: 'Msg) : ActorOp<'Reply> =
     actor {
         let! reply =
             target.Mb.PostAndAsyncReply(fun rc ->
-                msgFactory { Reply = fun r -> rc.Reply(r) })
+                (msg, { Reply = fun r -> rc.Reply(r) }))
 
         return reply
     }
 
 /// Send a message and await a reply with a timeout in milliseconds.
 /// Raises TimeoutException if no reply is received within the timeout.
-let callWithTimeout (timeout: int) (target: Actor<'TargetMsg>) (msgFactory: ReplyChannel<'Reply> -> 'TargetMsg) : ActorOp<'Reply> =
+let callWithTimeout (timeout: int) (target: Actor<'Msg * ReplyChannel<'Reply>>) (msg: 'Msg) : ActorOp<'Reply> =
     let mutable result: 'Reply option = None
     let rc: ReplyChannel<'Reply> = { Reply = fun r -> result <- Some r }
-    target.Post(msgFactory rc)
+    target.Post((msg, rc))
 
     let step = 5
 
@@ -278,22 +257,6 @@ let callWithTimeout (timeout: int) (target: Actor<'TargetMsg>) (msgFactory: Repl
 
 /// Receive next message (free function, for backwards compatibility).
 let receive<'Msg> (inbox: Actor<'Msg>) : Async<'Msg> = inbox.Receive()
-
-/// Send a message and await a reply (non-blocking, inside actor { }).
-let callAsync<'Reply, 'Msg> (target: Actor<'Msg>) (msg: 'Msg) : Async<'Reply> =
-    target.Mb.PostAndAsyncReply(fun rc ->
-        unbox (box (rc, box 0, box msg)))
-
-/// Receive a message with a reply channel (inside actor { }).
-let receiveAndReply<'Msg, 'Reply> (inbox: Actor<obj>) : Async<'Msg * ReplyChannel<'Reply>> =
-    async {
-        let! raw = inbox.Receive()
-        let (rc, _ref, msgRaw) = unbox<obj * obj * obj> raw
-        let replyChannel: ReplyChannel<'Reply> = {
-            Reply = fun reply -> (unbox<Control.AsyncReplyChannel<'Reply>> rc).Reply(reply)
-        }
-        return (unbox<'Msg> msgRaw, replyChannel)
-    }
 
 #endif
 
@@ -395,6 +358,10 @@ let handleChildExit
 
 /// Send a message (fire and forget).
 let send (actor: Actor<'Msg>) (msg: 'Msg) : unit = actor.Post(msg)
+
+/// Fire-and-forget message to a call-capable actor (no-op reply channel).
+let cast (actor: Actor<'Msg * ReplyChannel<'Reply>>) (msg: 'Msg) : unit =
+    actor.Post((msg, { Reply = fun _ -> () }))
 
 /// Start a stateful actor with a message handler.
 let start (initialState: 'State) (handler: 'State -> 'Msg -> Next<'State>) : Actor<'Msg> =

--- a/test/ActorTest.fs
+++ b/test/ActorTest.fs
@@ -21,66 +21,66 @@ let actor_empty_test () =
 
 type SingleMsg =
     | SetValue of string
-    | GetValue of ReplyChannel<string>
+    | GetValue
 
 /// An actor can receive a single message.
 let actor_single_receive_test () =
     actor {
         let a =
-            start "" (fun state msg ->
+            start "" (fun state (msg, rc) ->
                 match msg with
                 | SetValue s -> Continue s
-                | GetValue rc ->
+                | GetValue ->
                     rc.Reply state
                     Continue state)
 
-        send a (SetValue "hello")
+        cast a (SetValue "hello")
         do! sleep 10
-        let! got = call a (fun rc -> GetValue rc)
+        let! got = call a GetValue
         shouldEqual "hello" got
     }
 
 type CollectIntMsg =
     | AddItem of int
-    | GetItems of ReplyChannel<int list>
+    | GetItems
 
 /// An actor can receive multiple messages in order.
 let actor_multiple_receive_test () =
     actor {
         let a =
-            start [] (fun items msg ->
+            start [] (fun items (msg, rc) ->
                 match msg with
                 | AddItem n -> Continue(items @ [ n ])
-                | GetItems rc ->
+                | GetItems ->
                     rc.Reply items
                     Continue items)
 
-        send a (AddItem 1)
-        send a (AddItem 2)
-        send a (AddItem 3)
+        cast a (AddItem 1)
+        cast a (AddItem 2)
+        cast a (AddItem 3)
         do! sleep 10
-        let! items = call a (fun rc -> GetItems rc)
+        let! items = call a GetItems
         shouldEqual [ 1; 2; 3 ] items
     }
 
 type PostMsg =
     | SetInt of int
-    | GetInt of ReplyChannel<int>
+    | GetInt
 
 /// Post is equivalent to send.
 let actor_post_test () =
     actor {
         let a =
-            start 0 (fun _state msg ->
+            start 0 (fun state (msg, rc) ->
                 match msg with
                 | SetInt n -> Continue n
-                | GetInt rc ->
-                    rc.Reply _state
-                    Continue _state)
+                | GetInt ->
+                    rc.Reply state
+                    Continue state)
 
-        a.Post(SetInt 42)
+        a.Post((SetInt 42, { Reply = fun _ -> () }))
         do! sleep 10
-        let! got = call a (fun rc -> GetInt rc)
+        let! got = call a GetInt
         shouldEqual 42 got
     }
 
@@ -91,53 +91,53 @@ let actor_post_test () =
 type CounterMsg =
     | Increment
     | Decrement
-    | GetCount of ReplyChannel<int>
+    | GetCount
 
 /// start creates a stateful actor with a handler.
 let actor_start_basic_test () =
     actor {
         let counter =
-            start 0 (fun count msg ->
+            start 0 (fun count (msg, rc) ->
                 match msg with
                 | Increment -> Continue(count + 1)
                 | Decrement -> Continue(count - 1)
-                | GetCount rc ->
+                | GetCount ->
                     rc.Reply count
                     Continue count)
 
-        send counter Increment
-        send counter Increment
-        send counter Increment
-        send counter Decrement
+        cast counter Increment
+        cast counter Increment
+        cast counter Increment
+        cast counter Decrement
 
         do! sleep 10
 
-        let! count = call counter (fun rc -> GetCount rc)
+        let! count = call counter GetCount
         shouldEqual 2 count
     }
 
 type Command =
     | Add of int
-    | Done of ReplyChannel<int>
+    | Done
 
 /// Stop terminates the actor handler loop.
 let actor_start_stop_test () =
     actor {
         let counter =
-            start 0 (fun count msg ->
+            start 0 (fun count (msg, rc) ->
                 match msg with
                 | Add _ -> Continue(count + 1)
-                | Done rc ->
+                | Done ->
                     rc.Reply count
                     Stop)
 
-        send counter (Add 1)
-        send counter (Add 1)
-        send counter (Add 1)
+        cast counter (Add 1)
+        cast counter (Add 1)
+        cast counter (Add 1)
 
         do! sleep 10
 
-        let! count = call counter (fun rc -> Done rc)
+        let! count = call counter Done
         shouldEqual 3 count
     }
 
@@ -149,21 +149,21 @@ let actor_start_stop_test () =
 let actor_call_reply_test () =
     actor {
         let counter =
-            start 0 (fun count msg ->
+            start 0 (fun count (msg, rc) ->
                 match msg with
                 | Increment -> Continue(count + 1)
                 | Decrement -> Continue(count - 1)
-                | GetCount rc ->
+                | GetCount ->
                     rc.Reply count
                     Continue count)
 
-        send counter Increment
-        send counter Increment
-        send counter Increment
+        cast counter Increment
+        cast counter Increment
+        cast counter Increment
 
         do! sleep 10
 
-        let! count = call counter (fun rc -> GetCount rc)
+        let! count = call counter GetCount
         shouldEqual 3 count
     }
 
@@ -171,23 +171,23 @@ let actor_call_reply_test () =
 let actor_multiple_calls_test () =
     actor {
         let counter =
-            start 0 (fun count msg ->
+            start 0 (fun count (msg, rc) ->
                 match msg with
                 | Increment -> Continue(count + 1)
                 | Decrement -> Continue(count - 1)
-                | GetCount rc ->
+                | GetCount ->
                     rc.Reply count
                     Continue count)
 
-        send counter Increment
+        cast counter Increment
         do! sleep 10
-        let! c1 = call counter (fun rc -> GetCount rc)
+        let! c1 = call counter GetCount
         shouldEqual 1 c1
 
-        send counter Increment
-        send counter Increment
+        cast counter Increment
+        cast counter Increment
         do! sleep 10
-        let! c2 = call counter (fun rc -> GetCount rc)
+        let! c2 = call counter GetCount
         shouldEqual 3 c2
     }
 
@@ -197,28 +197,28 @@ let actor_multiple_calls_test () =
 
 type CollectorMsg<'T> =
     | Collect of 'T
-    | GetResults of ReplyChannel<'T list>
+    | GetResults
 
 /// Spawned actor can send messages to other actors.
 let actor_spawn_send_test () =
     actor {
         let collector =
-            start [] (fun results msg ->
+            start [] (fun results (msg, rc) ->
                 match msg with
                 | Collect x -> Continue(results @ [ x ])
-                | GetResults rc ->
+                | GetResults ->
                     rc.Reply results
                     Continue results)
 
         let _worker: Actor<string> =
             spawn (fun _inbox ->
-                send collector (Collect "hello")
-                send collector (Collect "world")
+                cast collector (Collect "hello")
+                cast collector (Collect "world")
                 actor { return () })
 
         do! sleep 50
 
-        let! results = call collector (fun rc -> GetResults rc)
+        let! results = call collector GetResults
         shouldEqual [ "hello"; "world" ] results
     }
 
@@ -226,10 +226,10 @@ let actor_spawn_send_test () =
 let actor_spawn_receive_forward_test () =
     actor {
         let collector =
-            start [] (fun results msg ->
+            start [] (fun results (msg, rc) ->
                 match msg with
                 | Collect x -> Continue(results @ [ x ])
-                | GetResults rc ->
+                | GetResults ->
                     rc.Reply results
                     Continue results)
 
@@ -238,7 +238,7 @@ let actor_spawn_receive_forward_test () =
                 let rec loop () =
                     actor {
                         let! n = inbox.Receive()
-                        send collector (Collect(n * 2))
+                        cast collector (Collect(n * 2))
                         return! loop ()
                     }
 
@@ -250,18 +250,18 @@ let actor_spawn_receive_forward_test () =
 
         do! sleep 50
 
-        let! results = call collector (fun rc -> GetResults rc)
+        let! results = call collector GetResults
         shouldEqual [ 2; 4; 6 ] results
     }
 
 /// Actor can do async work (sleep) before responding.
 let actor_async_work_test () =
     actor {
-        let worker: Actor<ReplyChannel<string>> =
+        let worker: Actor<unit * ReplyChannel<string>> =
             spawn (fun inbox ->
                 let rec loop () =
                     actor {
-                        let! rc = inbox.Receive()
+                        let! (), rc = inbox.Receive()
                         do! sleep 10
                         rc.Reply "done"
                         return! loop ()
@@ -269,7 +269,7 @@ let actor_async_work_test () =
 
                 loop ())
 
-        let! result = call worker (fun rc -> rc)
+        let! result = call worker ()
         shouldEqual "done" result
     }
 
@@ -279,26 +279,26 @@ let actor_async_work_test () =
 
 type TimerMsg =
     | Tick
-    | GetTicks of ReplyChannel<int>
+    | GetTicks
 
 /// schedule fires callbacks after a delay.
 let actor_schedule_test () =
     actor {
         let ticker =
-            start 0 (fun count msg ->
+            start 0 (fun count (msg, rc) ->
                 match msg with
                 | Tick -> Continue(count + 1)
-                | GetTicks rc ->
+                | GetTicks ->
                     rc.Reply count
                     Continue count)
 
-        schedule 10 (fun () -> send ticker Tick) |> ignore
-        schedule 20 (fun () -> send ticker Tick) |> ignore
-        schedule 30 (fun () -> send ticker Tick) |> ignore
+        schedule 10 (fun () -> cast ticker Tick) |> ignore
+        schedule 20 (fun () -> cast ticker Tick) |> ignore
+        schedule 30 (fun () -> cast ticker Tick) |> ignore
 
         do! sleep 100
 
-        let! ticks = call ticker (fun rc -> GetTicks rc)
+        let! ticks = call ticker GetTicks
         shouldEqual 3 ticks
     }
 
@@ -345,10 +345,20 @@ let actor_linked_crash_test () =
 // supervised actor tests
 // ============================================================================
 
+/// A reporter actor for cross-process state sharing on BEAM.
+/// Set via cast (Some value), query via call None.
+let reporter initial =
+    start initial (fun state (msg, rc) ->
+        match msg with
+        | Some v -> Continue v
+        | None -> rc.Reply state; Continue state)
+
 /// spawnSupervised restarts a crashed child when strategy says Restart.
 let actor_supervised_restart_test () =
     actor {
-        let parent: Actor<obj> =
+        let restarts = reporter 0
+
+        let _parent: Actor<obj> =
             spawn (fun inbox ->
                 trapExits ()
 
@@ -376,30 +386,24 @@ let actor_supervised_restart_test () =
                         | Some exited ->
                             let restarted = handleChildExit inbox child exited
                             let newCount = if restarted then restartCount + 1 else restartCount
+                            cast restarts (Some newCount)
                             return! loop newCount
-                        | None ->
-                            // Check if it's a call for the restart count
-                            let rc = unbox<ReplyChannel<int>> msg
-
-                            try
-                                rc.Reply restartCount
-                            with _ ->
-                                ()
-
-                            return! loop restartCount
+                        | None -> return! loop restartCount
                     }
 
                 loop 0)
 
         do! sleep 200
-        let! count = call parent (fun rc -> box rc)
+        let! count = call restarts None
         shouldBeTrue (count >= 1)
     }
 
 /// spawnSupervised stops child when strategy says Stop.
 let actor_supervised_stop_test () =
     actor {
-        let parent: Actor<obj> =
+        let flag = reporter false
+
+        let _parent: Actor<obj> =
             spawn (fun inbox ->
                 trapExits ()
 
@@ -416,28 +420,23 @@ let actor_supervised_stop_test () =
 
                 send child.Actor "boom"
 
-                let rec loop stopped =
+                let rec loop () =
                     actor {
                         let! msg = inbox.Receive()
 
                         match tryAsChildExited msg with
                         | Some exited ->
                             let restarted = handleChildExit inbox child exited
-                            return! loop (not restarted)
-                        | None ->
-                            try
-                                let rc = unbox<ReplyChannel<bool>> msg
-                                rc.Reply stopped
-                            with _ ->
-                                ()
+                            if not restarted then cast flag (Some true)
+                        | None -> ()
 
-                            return! loop stopped
+                        return! loop ()
                     }
 
-                loop false)
+                loop ())
 
         do! sleep 200
-        let! stopped = call parent (fun rc -> box rc)
+        let! stopped = call flag None
         shouldBeTrue stopped
     }
 
@@ -448,7 +447,9 @@ let actor_supervised_stop_test () =
 /// StopAbnormal triggers ChildExited on the parent via spawnLinked.
 let actor_stop_abnormal_test () =
     actor {
-        let parent: Actor<obj> =
+        let flag = reporter false
+
+        let _parent: Actor<obj> =
             spawn (fun inbox ->
                 trapExits ()
 
@@ -468,35 +469,32 @@ let actor_stop_abnormal_test () =
 
                 send stoppingChild.Actor "stop-abnormal"
 
-                let rec loop gotExit =
+                let rec loop () =
                     actor {
                         let! msg = inbox.Receive()
 
                         match tryAsChildExited msg with
                         | Some exited ->
                             handleChildExit inbox stoppingChild exited |> ignore
-                            return! loop true
-                        | None ->
-                            try
-                                let rc = unbox<ReplyChannel<bool>> msg
-                                rc.Reply gotExit
-                            with _ ->
-                                ()
+                            cast flag (Some true)
+                        | None -> ()
 
-                            return! loop gotExit
+                        return! loop ()
                     }
 
-                loop false)
+                loop ())
 
         do! sleep 200
-        let! gotExit = call parent (fun rc -> box rc)
+        let! gotExit = call flag None
         shouldBeTrue gotExit
     }
 
 /// StopAbnormal in start handler propagates as ChildExited to parent.
 let actor_start_stop_abnormal_test () =
     actor {
-        let parent: Actor<obj> =
+        let flag = reporter false
+
+        let _parent: Actor<obj> =
             spawn (fun inbox ->
                 trapExits ()
 
@@ -515,35 +513,32 @@ let actor_start_stop_abnormal_test () =
 
                 send child.Actor "fail"
 
-                let rec loop gotExit =
+                let rec loop () =
                     actor {
                         let! msg = inbox.Receive()
 
                         match tryAsChildExited msg with
                         | Some exited ->
                             handleChildExit inbox child exited |> ignore
-                            return! loop true
-                        | None ->
-                            try
-                                let rc = unbox<ReplyChannel<bool>> msg
-                                rc.Reply gotExit
-                            with _ ->
-                                ()
+                            cast flag (Some true)
+                        | None -> ()
 
-                            return! loop gotExit
+                        return! loop ()
                     }
 
-                loop false)
+                loop ())
 
         do! sleep 200
-        let! gotExit = call parent (fun rc -> box rc)
+        let! gotExit = call flag None
         shouldBeTrue gotExit
     }
 
 /// start handler returning StopAbnormal raises and triggers supervision.
 let actor_start_handler_stop_abnormal_test () =
     actor {
-        let parent: Actor<obj> =
+        let flag = reporter false
+
+        let _parent: Actor<obj> =
             spawn (fun inbox ->
                 trapExits ()
 
@@ -568,28 +563,23 @@ let actor_start_handler_stop_abnormal_test () =
 
                 send child.Actor "crash"
 
-                let rec loop gotExit =
+                let rec loop () =
                     actor {
                         let! msg = inbox.Receive()
 
                         match tryAsChildExited msg with
                         | Some exited ->
                             handleChildExit inbox child exited |> ignore
-                            return! loop true
-                        | None ->
-                            try
-                                let rc = unbox<ReplyChannel<bool>> msg
-                                rc.Reply gotExit
-                            with _ ->
-                                ()
+                            cast flag (Some true)
+                        | None -> ()
 
-                            return! loop gotExit
+                        return! loop ()
                     }
 
-                loop false)
+                loop ())
 
         do! sleep 200
-        let! gotExit = call parent (fun rc -> box rc)
+        let! gotExit = call flag None
         shouldBeTrue gotExit
     }
 
@@ -598,34 +588,34 @@ let actor_start_handler_stop_abnormal_test () =
 // ============================================================================
 
 type TimeoutMsg =
-    | Slow of ReplyChannel<string>
-    | Fast of ReplyChannel<string>
+    | Slow
+    | Fast
 
 /// callWithTimeout succeeds when reply arrives within timeout.
 let actor_call_with_timeout_success_test () =
     actor {
         let worker =
-            start () (fun _state msg ->
+            start () (fun _state (msg, rc) ->
                 match msg with
-                | Fast rc ->
+                | Fast ->
                     rc.Reply "fast"
                     Continue()
-                | Slow rc ->
+                | Slow ->
                     rc.Reply "slow"
                     Continue())
 
-        let! result = callWithTimeout 1000 worker (fun rc -> Fast rc)
+        let! result = callWithTimeout 1000 worker Fast
         shouldEqual "fast" result
     }
 
 /// callWithTimeout raises TimeoutException when reply takes too long.
 let actor_call_with_timeout_expires_test () =
     actor {
-        let worker: Actor<ReplyChannel<string>> =
+        let worker: Actor<unit * ReplyChannel<string>> =
             spawn (fun inbox ->
                 let rec loop () =
                     actor {
-                        let! _rc = inbox.Receive()
+                        let! (), _rc = inbox.Receive()
                         // Never reply — let it time out
                         do! sleep 5000
                         return! loop ()
@@ -636,7 +626,7 @@ let actor_call_with_timeout_expires_test () =
         let mutable timedOut = false
 
         try
-            let! _result = callWithTimeout 50 worker (fun rc -> rc)
+            let! _result = callWithTimeout 50 worker ()
             ()
         with :? System.TimeoutException ->
             timedOut <- true

--- a/test/Program.fs
+++ b/test/Program.fs
@@ -43,8 +43,6 @@ let mainAsync =
 
         // supervision
         let! r13 = runTest "actor_linked_crash" actor_linked_crash_test
-
-        // supervised actors
         let! r14 = runTest "actor_supervised_restart" actor_supervised_restart_test
         let! r15 = runTest "actor_supervised_stop" actor_supervised_stop_test
 


### PR DESCRIPTION
## Summary
- Redesigned the `call`/reply API so `ReplyChannel` is part of the actor's type signature (`Actor<'Msg * ReplyChannel<'Reply>>`) rather than embedded in user-defined DU cases
- Added `cast` for fire-and-forget messages to call-capable actors (sends a no-op `ReplyChannel`)
- Removed `callAsync` and `receiveAndReply` — the tuple pattern replaces both
- Updated all tests and the interop example to the new API

## Test plan
- [x] All 21 tests pass on .NET (`dotnet run --project test`)
- [x] All 21 tests pass on BEAM (`rebar3 compile && escript _build/default/lib/test/ebin/program`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)