### PR TITLE
feat: add unified pid function with no compiler directives

### DIFF
--- a/src/Fable.Actor/Actor.fs
+++ b/src/Fable.Actor/Actor.fs
@@ -66,6 +66,8 @@ type Actor<'Msg> = {
     Cts: System.Threading.CancellationTokenSource
 } with
 
+    member this.Pid : obj = box this.Mb
+
     member this.Receive() : Async<'Msg> = this.Mb.Receive()
 
     member this.Post(msg: 'Msg) =
@@ -418,3 +420,7 @@ let cancelTimer (timer: obj) : unit =
     (unbox<System.Threading.CancellationTokenSource> timer).Cancel()
 
 #endif
+
+/// Extract the raw platform handle from an actor.
+/// BEAM: returns the Erlang PID. Non-BEAM: returns a boxed MailboxProcessor.
+let pid (actor: Actor<'Msg>) : obj = actor.Pid


### PR DESCRIPTION
## Summary
- Add a computed `Pid` property to the non-BEAM `Actor<'Msg>` type (`box this.Mb`), matching the existing BEAM record field
- Define a single directive-free `pid` function that works on both platforms via the shared `Pid` property
- Eliminates the need for `#if FABLE_COMPILER_BEAM` / `#if !FABLE_COMPILER_BEAM` around `pid`

## Test plan
- [x] `dotnet build src/Fable.Actor` passes
- [ ] Verify BEAM compilation still works with Fable
- [ ] Verify non-BEAM targets (Python, JS) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)