### PR TITLE
refactor: use Fable.Beam.Erlang typed bindings instead of local Emits

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "fable": {
-      "version": "5.0.0-rc.3",
+      "version": "5.0.0-rc.5",
       "commands": [
         "fable"
       ],

--- a/examples/timeflies-beam/rebar.config
+++ b/examples/timeflies-beam/rebar.config
@@ -1,5 +1,6 @@
 {deps, [
     cowboy,
+    {cowlib, {git, "https://github.com/ninenines/cowlib", {tag, "2.16.0"}}},
     jsx
 ]}.
 

--- a/examples/timeflies-beam/src/Timeflies.fsproj
+++ b/examples/timeflies-beam/src/Timeflies.fsproj
@@ -8,7 +8,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../timeflies/src/Timeflies.Common.fsproj" />
-    <PackageReference Include="Fable.Beam" Version="5.0.0-rc.4" />
-    <PackageReference Include="Fable.Beam.Cowboy" Version="5.0.0-rc.4" />
+    <PackageReference Include="Fable.Beam" Version="5.0.0-rc.10" />
+    <PackageReference Include="Fable.Beam.Cowboy" Version="5.0.0-rc.10" />
   </ItemGroup>
 </Project>

--- a/src/Fable.Actor/Actor.fs
+++ b/src/Fable.Actor/Actor.fs
@@ -17,6 +17,7 @@ open Fable.Actor.Types
 
 #if FABLE_COMPILER_BEAM
 
+open Fable.Beam.Erlang
 open Fable.Actor.Platform
 
 // === BEAM: CPS-based, native processes ===
@@ -24,7 +25,7 @@ open Fable.Actor.Platform
 type ActorOp<'T> = { Run: ('T -> unit) -> unit }
 
 type Actor<'Msg> = {
-    Pid: obj
+    Pid: Pid
 } with
 
     member _.Receive() : ActorOp<'Msg> = {
@@ -100,8 +101,8 @@ let actor = ActorBuilder()
 /// Spawn an actor. Body receives inbox (self-reference) for Receive/Post.
 let spawn (body: Actor<'Msg> -> ActorOp<unit>) : Actor<'Msg> =
     let rawPid =
-        spawnProcess (fun () ->
-            let me: Actor<'Msg> = { Pid = selfPid () }
+        Fable.Beam.Erlang.spawn (fun () ->
+            let me: Actor<'Msg> = { Pid = Fable.Beam.Erlang.self () }
             (body me).Run(fun () -> ()))
 
     { Pid = rawPid }
@@ -109,14 +110,14 @@ let spawn (body: Actor<'Msg> -> ActorOp<unit>) : Actor<'Msg> =
 /// Spawn a linked child actor (parent gets EXIT signal on crash).
 let spawnLinked (_parent: Actor<'ParentMsg>) (body: Actor<'Msg> -> ActorOp<unit>) : Actor<'Msg> =
     let rawPid =
-        spawnLinkedProcess (fun () ->
-            let me: Actor<'Msg> = { Pid = selfPid () }
+        spawnLink (fun () ->
+            let me: Actor<'Msg> = { Pid = Fable.Beam.Erlang.self () }
             (body me).Run(fun () -> ()))
 
     { Pid = rawPid }
 
 /// Get own pid (only valid inside actor body).
-let self<'Msg> () : Actor<'Msg> = { Pid = selfPid () }
+let self<'Msg> () : Actor<'Msg> = { Pid = Fable.Beam.Erlang.self () }
 
 /// Kill an actor and its linked children.
 let kill (actor: Actor<'Msg>) : unit = killProcess actor.Pid
@@ -131,7 +132,7 @@ let formatReason (reason: obj) : string = Platform.formatReason reason
 let call (actor: Actor<'Msg * ReplyChannel<'Reply>>) (msg: 'Msg) : ActorOp<'Reply> = {
     Run = fun cont ->
         let ref = makeRef ()
-        let callerPid = selfPid ()
+        let callerPid = Fable.Beam.Erlang.self ()
         let rc: ReplyChannel<'Reply> = { Reply = fun reply -> sendReply callerPid ref reply }
         sendMsg actor.Pid (box (msg, rc))
         cont (unbox (recvReply ref))
@@ -142,7 +143,7 @@ let call (actor: Actor<'Msg * ReplyChannel<'Reply>>) (msg: 'Msg) : ActorOp<'Repl
 let callWithTimeout (timeout: int) (actor: Actor<'Msg * ReplyChannel<'Reply>>) (msg: 'Msg) : ActorOp<'Reply> = {
     Run = fun cont ->
         let ref = makeRef ()
-        let callerPid = selfPid ()
+        let callerPid = Fable.Beam.Erlang.self ()
         let rc: ReplyChannel<'Reply> = { Reply = fun reply -> sendReply callerPid ref reply }
         sendMsg actor.Pid (box (msg, rc))
 
@@ -382,8 +383,8 @@ let start (initialState: 'State) (handler: 'State -> 'Msg -> Next<'State>) : Act
 
 #if FABLE_COMPILER_BEAM
     let rawPid =
-        spawnProcess (fun () ->
-            let me: Actor<'Msg> = { Pid = selfPid () }
+        Fable.Beam.Erlang.spawn (fun () ->
+            let me: Actor<'Msg> = { Pid = Fable.Beam.Erlang.self () }
             (body me).Run(fun () -> ()))
 
     { Pid = rawPid }
@@ -422,5 +423,8 @@ let cancelTimer (timer: obj) : unit =
 #endif
 
 /// Extract the raw platform handle from an actor.
-/// BEAM: returns the Erlang PID. Non-BEAM: returns a boxed MailboxProcessor.
+#if FABLE_COMPILER_BEAM
+let pid (actor: Actor<'Msg>) : Pid = actor.Pid
+#else
 let pid (actor: Actor<'Msg>) : obj = actor.Pid
+#endif

--- a/src/Fable.Actor/Fable.Actor.fsproj
+++ b/src/Fable.Actor/Fable.Actor.fsproj
@@ -22,6 +22,7 @@
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Fable.Beam" Version="5.0.0-rc.10" />
     <PackageReference Include="Fable.Core" Version="5.0.0-rc.1" />
   </ItemGroup>
 </Project>

--- a/src/Fable.Actor/Platform.fs
+++ b/src/Fable.Actor/Platform.fs
@@ -1,8 +1,7 @@
 /// Platform primitives for BEAM target.
 ///
-/// Replaces the .erl files with F# using [<Emit>] bindings,
-/// BeamInterop.Erlang.receive<'T> for selective receive, and
-/// emitErlExpr for bound-variable receive patterns.
+/// Delegates to Fable.Beam.Erlang for standard BIFs and keeps only
+/// actor-specific protocol Emits (tagged messages, selective receive).
 module Fable.Actor.Platform
 
 #if FABLE_COMPILER_BEAM
@@ -10,43 +9,26 @@ module Fable.Actor.Platform
 open Fable.Core
 open Fable.Core.BeamInterop
 open Fable.Actor.Types
+open Fable.Beam.Erlang
 
 // ============================================================================
-// BEAM BIF bindings
+// Atom literals
 // ============================================================================
 
-[<Emit("erlang:self()")>]
-let selfPid () : obj = nativeOnly
+[<Emit("kill")>]
+let private atomKill : obj = nativeOnly
 
-[<Emit("erlang:spawn(fun() -> $0(ok) end)")>]
-let spawnProcess (f: unit -> unit) : obj = nativeOnly
+[<Emit("normal")>]
+let private atomNormal : obj = nativeOnly
 
-[<Emit("erlang:spawn_link(fun() -> $0(ok) end)")>]
-let spawnLinkedProcess (f: unit -> unit) : obj = nativeOnly
+// ============================================================================
+// Process helpers (use Fable.Beam.Erlang with actor-specific atoms)
+// ============================================================================
 
-[<Emit("erlang:make_ref()")>]
-let makeRef () : obj = nativeOnly
-
-[<Emit("erlang:exit($0, kill)")>]
-let killProcess (pid: obj) : unit = nativeOnly
-
-[<Emit("erlang:exit(normal)")>]
-let exitNormal () : unit = nativeOnly
-
-[<Emit("erlang:process_flag(trap_exit, true)")>]
-let trapExits () : unit = nativeOnly
-
-[<Emit("erlang:monitor(process, $0)")>]
-let monitorProcess (pid: obj) : obj = nativeOnly
-
-[<Emit("erlang:demonitor($0, [flush])")>]
-let demonitorProcess (ref: obj) : unit = nativeOnly
-
-[<Emit("erlang:list_to_binary(io_lib:format(<<\"~p\">>, [$0]))")>]
-let formatReason (reason: obj) : string = nativeOnly
-
-[<Emit("$0 =:= $1")>]
-let exactEquals (a: obj) (b: obj) : bool = nativeOnly
+let killProcess (pid: Pid) : unit = exitPid pid atomKill
+let exitNormal () : unit = exit atomNormal
+let trapExits () : unit = trapExit ()
+let formatReason (reason: obj) : string = formatTerm reason
 
 // ============================================================================
 // Internal message protocol
@@ -57,10 +39,7 @@ let exactEquals (a: obj) (b: obj) : bool = nativeOnly
 type InternalMsg =
     | [<CompiledName("fable_actor_msg")>] ActorMsg of payload: obj
     | [<CompiledName("fable_actor_timer")>] ActorTimer of ref: obj * callback: (obj -> unit)
-    | [<CompiledName("EXIT")>] Exit of pid: obj * reason: obj
-
-[<Emit("normal")>]
-let private atomNormal : obj = nativeOnly
+    | [<CompiledName("EXIT")>] Exit of pid: Pid * reason: obj
 
 // ============================================================================
 // Message passing
@@ -68,11 +47,11 @@ let private atomNormal : obj = nativeOnly
 
 /// Send a tagged user message: Pid ! {fable_actor_msg, Msg}
 [<Emit("$0 ! {fable_actor_msg, $1}, ok")>]
-let sendMsg (pid: obj) (msg: obj) : unit = nativeOnly
+let sendMsg (pid: Pid) (msg: obj) : unit = nativeOnly
 
 /// Send a tagged reply: Pid ! {fable_actor_reply, Ref, Value}
 [<Emit("$0 ! {fable_actor_reply, $1, $2}, ok")>]
-let sendReply (pid: obj) (ref: obj) (value: obj) : unit = nativeOnly
+let sendReply (pid: Pid) (ref: Ref) (value: obj) : unit = nativeOnly
 
 /// CPS receive: blocks until a user message arrives.
 /// Dispatches timer callbacks and EXIT signals transparently.
@@ -90,17 +69,17 @@ let rec receiveMsg (cont: obj -> unit) : unit =
         callback (box ())
         receiveMsg cont
     | Exit(_, reason) when exactEquals reason atomNormal -> receiveMsg cont
-    | Exit(pid, reason) -> cont (box ({ Pid = pid; Reason = reason }: ChildExited))
+    | Exit(pid, reason) -> cont (box ({ Pid = box pid; Reason = reason }: ChildExited))
 
 /// Blocking selective receive for a reply matching a specific ref.
 /// Uses emitErlExpr to preserve Erlang's bound-variable semantics —
 /// only the message with the matching ref is consumed from the mailbox.
-let recvReply (ref: obj) : obj =
+let recvReply (ref: Ref) : obj =
     emitErlExpr ref "receive {fable_actor_reply, $0, FableReply} -> FableReply end"
 
 /// Selective receive for a reply with timeout.
 /// Returns Some(reply) or None on timeout.
-let recvReplyWithTimeout (ref: obj) (timeout: int) : obj option =
+let recvReplyWithTimeout (ref: Ref) (timeout: int) : obj option =
     emitErlExpr (ref, timeout) "receive {fable_actor_reply, $0, FableReply} -> {some, FableReply} after $1 -> undefined end"
 
 // ============================================================================
@@ -120,10 +99,10 @@ type private TimerControl =
 /// Schedule a callback after ms milliseconds.
 /// Returns a handle (pid) for cancellation.
 let timerSchedule (ms: int) (callback: unit -> unit) : obj =
-    spawnProcess (fun () ->
+    box (spawn (fun () ->
         match Erlang.receive<TimerControl> ms with
         | Some Cancel -> ()
-        | None -> callback ())
+        | None -> callback ()))
 
 /// Cancel a scheduled timer.
 [<Emit("$0 ! cancel, ok")>]


### PR DESCRIPTION
## Summary
- Replace 11 duplicate `[<Emit>]` BIF bindings in Platform.fs with `Fable.Beam.Erlang` calls, using typed `Pid`/`Ref` instead of `obj`
- BEAM `Actor<'Msg>.Pid` is now `Fable.Beam.Erlang.Pid` — non-BEAM keeps computed `Pid` property returning `obj`
- Keep only actor-specific protocol Emits (sendMsg, receiveMsg, recvReply, etc.)
- Pin cowlib git dep for rebar3 3.19 compatibility

## Test plan
- [x] `dotnet build src/Fable.Actor` passes
- [ ] Verify BEAM compilation with Fable
- [ ] Verify timeflies-beam example runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)