### PR TITLE
chore: bump Fable.Beam to 5.0.0-rc.14

### DIFF
--- a/examples/timeflies-beam/src/Timeflies.fsproj
+++ b/examples/timeflies-beam/src/Timeflies.fsproj
@@ -8,7 +8,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../timeflies/src/Timeflies.Common.fsproj" />
-    <PackageReference Include="Fable.Beam" Version="5.0.0-rc.10" />
-    <PackageReference Include="Fable.Beam.Cowboy" Version="5.0.0-rc.10" />
+    <PackageReference Include="Fable.Beam" Version="5.0.0-rc.14" />
+    <PackageReference Include="Fable.Beam.Cowboy" Version="5.0.0-rc.14" />
   </ItemGroup>
 </Project>

--- a/src/Fable.Actor/Fable.Actor.fsproj
+++ b/src/Fable.Actor/Fable.Actor.fsproj
@@ -22,7 +22,7 @@
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Fable.Beam" Version="5.0.0-rc.10" />
+    <PackageReference Include="Fable.Beam" Version="5.0.0-rc.14" />
     <PackageReference Include="Fable.Core" Version="5.0.0-rc.1" />
   </ItemGroup>
 </Project>

--- a/src/Fable.Actor/Platform.fs
+++ b/src/Fable.Actor/Platform.fs
@@ -27,7 +27,7 @@ let private atomNormal : obj = nativeOnly
 
 let killProcess (pid: Pid) : unit = exitPid pid atomKill
 let exitNormal () : unit = exit atomNormal
-let trapExits () : unit = trapExit ()
+let trapExits () : unit = trapExit () |> ignore
 let formatReason (reason: obj) : string = formatTerm reason
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Bump `Fable.Beam` from 5.0.0-rc.10 to 5.0.0-rc.14 in core library and timeflies-beam example
- Adapt to `trapExit()` return type change (`unit` → `bool`) from [fable-compiler/Fable.Beam#29](https://github.com/fable-compiler/Fable.Beam/pull/29)
- Bump `Fable.Beam.Cowboy` to 5.0.0-rc.14 in timeflies-beam example to avoid version downgrade conflict

## Test plan
- [x] `dotnet build src/Fable.Actor` passes
- [x] `dotnet build examples/timeflies-beam/src/Timeflies.fsproj` passes
- [ ] Fable BEAM compilation still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)