### PR TITLE
chore: bump Fable.Beam to 5.0.0-rc.15 and improve typings

### DIFF
--- a/examples/timeflies-beam/src/Timeflies.fsproj
+++ b/examples/timeflies-beam/src/Timeflies.fsproj
@@ -8,7 +8,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../timeflies/src/Timeflies.Common.fsproj" />
-    <PackageReference Include="Fable.Beam" Version="5.0.0-rc.14" />
-    <PackageReference Include="Fable.Beam.Cowboy" Version="5.0.0-rc.14" />
+    <PackageReference Include="Fable.Beam" Version="5.0.0-rc.15" />
+    <PackageReference Include="Fable.Beam.Cowboy" Version="5.0.0-rc.15" />
   </ItemGroup>
 </Project>

--- a/src/Fable.Actor/Actor.fs
+++ b/src/Fable.Actor/Actor.fs
@@ -49,11 +49,12 @@ type ActorBuilder() =
     }
 
     member _.TryWith(body: ActorOp<'T>, handler: exn -> ActorOp<'T>) : ActorOp<'T> = {
-        Run = fun cont ->
-            try
-                body.Run cont
-            with ex ->
-                (handler ex).Run cont
+        Run =
+            fun cont ->
+                try
+                    body.Run cont
+                with ex ->
+                    (handler ex).Run cont
     }
 
 #else
@@ -67,7 +68,7 @@ type Actor<'Msg> = {
     Cts: System.Threading.CancellationTokenSource
 } with
 
-    member this.Pid : obj = box this.Mb
+    member this.Pid: obj = box this.Mb
 
     member this.Receive() : Async<'Msg> = this.Mb.Receive()
 
@@ -85,8 +86,7 @@ type ActorBuilder() =
     member _.Combine(first: Async<unit>, second: Async<'T>) : Async<'T> =
         async.Combine(first, async.Delay(fun () -> second))
 
-    member _.TryWith(body: Async<'T>, handler: exn -> Async<'T>) : Async<'T> =
-        async.TryWith(body, handler)
+    member _.TryWith(body: Async<'T>, handler: exn -> Async<'T>) : Async<'T> = async.TryWith(body, handler)
 
 #endif
 
@@ -130,26 +130,36 @@ let formatReason (reason: obj) : string = Platform.formatReason reason
 
 /// Send a message and await a reply (inside actor { }).
 let call (actor: Actor<'Msg * ReplyChannel<'Reply>>) (msg: 'Msg) : ActorOp<'Reply> = {
-    Run = fun cont ->
-        let ref = makeRef ()
-        let callerPid = Fable.Beam.Erlang.self ()
-        let rc: ReplyChannel<'Reply> = { Reply = fun reply -> sendReply callerPid ref reply }
-        sendMsg actor.Pid (box (msg, rc))
-        cont (unbox (recvReply ref))
+    Run =
+        fun cont ->
+            let ref = makeRef ()
+            let callerPid = Fable.Beam.Erlang.self ()
+
+            let rc: ReplyChannel<'Reply> = {
+                Reply = fun reply -> sendReply callerPid ref reply
+            }
+
+            sendMsg actor.Pid (box (msg, rc))
+            cont (unbox (recvReply ref))
 }
 
 /// Send a message and await a reply with a timeout in milliseconds.
 /// Raises TimeoutException if no reply is received within the timeout.
 let callWithTimeout (timeout: int) (actor: Actor<'Msg * ReplyChannel<'Reply>>) (msg: 'Msg) : ActorOp<'Reply> = {
-    Run = fun cont ->
-        let ref = makeRef ()
-        let callerPid = Fable.Beam.Erlang.self ()
-        let rc: ReplyChannel<'Reply> = { Reply = fun reply -> sendReply callerPid ref reply }
-        sendMsg actor.Pid (box (msg, rc))
+    Run =
+        fun cont ->
+            let ref = makeRef ()
+            let callerPid = Fable.Beam.Erlang.self ()
 
-        match recvReplyWithTimeout ref timeout with
-        | Some reply -> cont (unbox<'Reply> reply)
-        | None -> raise (System.TimeoutException("Actor call timed out"))
+            let rc: ReplyChannel<'Reply> = {
+                Reply = fun reply -> sendReply callerPid ref reply
+            }
+
+            sendMsg actor.Pid (box (msg, rc))
+
+            match recvReplyWithTimeout ref timeout with
+            | Some reply -> cont (unbox<'Reply> reply)
+            | None -> raise (System.TimeoutException("Actor call timed out"))
 }
 
 /// Receive next message (free function).
@@ -163,7 +173,10 @@ let receive<'Msg> () : ActorOp<'Msg> = {
 /// When the external token is cancelled, the actor's CTS is also cancelled.
 let spawnWithToken (cancellationToken: System.Threading.CancellationToken) (body: Actor<'Msg> -> Async<unit>) : Actor<'Msg> =
     let cts = new System.Threading.CancellationTokenSource()
-    cancellationToken.Register(fun () -> cts.Cancel()) |> ignore
+
+    cancellationToken.Register(fun () -> cts.Cancel())
+    |> ignore
+
     let mutable inbox: Actor<'Msg> option = None
 
     let mb =
@@ -205,12 +218,7 @@ let spawnLinked (parent: Actor<'ParentMsg>) (body: Actor<'Msg> -> Async<unit>) :
                 try
                     do! body actor
                 with ex ->
-                    parent.Post(
-                        unbox {
-                            Pid = box mb
-                            Reason = box ex
-                        }
-                    )
+                    parent.Post(unbox { Pid = box mb; Reason = box ex })
             })
 
     match inbox with
@@ -228,9 +236,7 @@ let trapExits () : unit = ()
 /// Send a message and await a reply (inside actor { }).
 let call (target: Actor<'Msg * ReplyChannel<'Reply>>) (msg: 'Msg) : ActorOp<'Reply> =
     actor {
-        let! reply =
-            target.Mb.PostAndAsyncReply(fun rc ->
-                (msg, { Reply = fun r -> rc.Reply(r) }))
+        let! reply = target.Mb.PostAndAsyncReply(fun rc -> (msg, { Reply = fun r -> rc.Reply(r) }))
 
         return reply
     }
@@ -290,16 +296,17 @@ let spawnSupervised
     (body: Actor<'Msg> -> ActorOp<unit>)
     : SupervisedChild<'ParentMsg, 'Msg> =
     let child = spawnLinked parent body
-    { Actor = child; Body = body; Strategy = strategy }
+
+    {
+        Actor = child
+        Body = body
+        Strategy = strategy
+    }
 
 /// Handle a ChildExited event for a supervised child.
 /// Returns true if the child was restarted, false if stopped/not matching.
 /// Raises ProcessExitException if Escalate.
-let handleChildExit
-    (parent: Actor<'ParentMsg>)
-    (supervised: SupervisedChild<'ParentMsg, 'Msg>)
-    (exited: ChildExited)
-    : bool =
+let handleChildExit (parent: Actor<'ParentMsg>) (supervised: SupervisedChild<'ParentMsg, 'Msg>) (exited: ChildExited) : bool =
     let (OneForOne decider) = supervised.Strategy
 
     let ex =
@@ -330,16 +337,17 @@ let spawnSupervised
     (body: Actor<'Msg> -> Async<unit>)
     : SupervisedChild<'ParentMsg, 'Msg> =
     let child = spawnLinked parent body
-    { Actor = child; Body = body; Strategy = strategy }
+
+    {
+        Actor = child
+        Body = body
+        Strategy = strategy
+    }
 
 /// Handle a ChildExited event for a supervised child.
 /// Returns true if the child was restarted, false if stopped/not matching.
 /// Raises ProcessExitException if Escalate.
-let handleChildExit
-    (parent: Actor<'ParentMsg>)
-    (supervised: SupervisedChild<'ParentMsg, 'Msg>)
-    (exited: ChildExited)
-    : bool =
+let handleChildExit (parent: Actor<'ParentMsg>) (supervised: SupervisedChild<'ParentMsg, 'Msg>) (exited: ChildExited) : bool =
     let (OneForOne decider) = supervised.Strategy
 
     let ex =
@@ -394,16 +402,17 @@ let start (initialState: 'State) (handler: 'State -> 'Msg -> Next<'State>) : Act
 
 #if FABLE_COMPILER_BEAM
 
-/// Schedule a timer callback. Returns an opaque handle for cancellation.
-let schedule (ms: int) (callback: unit -> unit) : obj = timerSchedule ms callback
+/// Schedule a timer callback. Returns a typed handle for cancellation.
+let schedule (ms: int) (callback: unit -> unit) : TimerHandle =
+    TimerHandle(box (timerSchedule ms callback))
 
 /// Cancel a scheduled timer.
-let cancelTimer (timer: obj) : unit = timerCancel timer
+let cancelTimer (TimerHandle handle: TimerHandle) : unit = timerCancel (unbox<Pid> handle)
 
 #else
 
-/// Schedule a timer callback. Returns a cancellation handle.
-let schedule (ms: int) (callback: unit -> unit) : obj =
+/// Schedule a timer callback. Returns a typed handle for cancellation.
+let schedule (ms: int) (callback: unit -> unit) : TimerHandle =
     let cts = new System.Threading.CancellationTokenSource()
 
     Async.StartImmediate(
@@ -414,11 +423,11 @@ let schedule (ms: int) (callback: unit -> unit) : obj =
         cts.Token
     )
 
-    box cts
+    TimerHandle(box cts)
 
 /// Cancel a scheduled timer.
-let cancelTimer (timer: obj) : unit =
-    (unbox<System.Threading.CancellationTokenSource> timer).Cancel()
+let cancelTimer (TimerHandle handle: TimerHandle) : unit =
+    (unbox<System.Threading.CancellationTokenSource> handle).Cancel()
 
 #endif
 

--- a/src/Fable.Actor/Fable.Actor.fsproj
+++ b/src/Fable.Actor/Fable.Actor.fsproj
@@ -22,7 +22,7 @@
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Fable.Beam" Version="5.0.0-rc.14" />
+    <PackageReference Include="Fable.Beam" Version="5.0.0-rc.15" />
     <PackageReference Include="Fable.Core" Version="5.0.0-rc.1" />
   </ItemGroup>
 </Project>

--- a/src/Fable.Actor/Platform.fs
+++ b/src/Fable.Actor/Platform.fs
@@ -15,11 +15,8 @@ open Fable.Beam.Erlang
 // Atom literals
 // ============================================================================
 
-[<Emit("kill")>]
-let private atomKill : obj = nativeOnly
-
-[<Emit("normal")>]
-let private atomNormal : obj = nativeOnly
+let private atomKill: Atom = binaryToAtom "kill"
+let private atomNormal: Atom = binaryToAtom "normal"
 
 // ============================================================================
 // Process helpers (use Fable.Beam.Erlang with actor-specific atoms)
@@ -93,19 +90,17 @@ let isChildExited (msg: obj) : bool = nativeOnly
 // Timer
 // ============================================================================
 
-type private TimerControl =
-    | [<CompiledName("cancel")>] Cancel
+type private TimerControl = | [<CompiledName("cancel")>] Cancel
 
 /// Schedule a callback after ms milliseconds.
-/// Returns a handle (pid) for cancellation.
-let timerSchedule (ms: int) (callback: unit -> unit) : obj =
-    box (spawn (fun () ->
+/// Returns the timer process pid for cancellation.
+let timerSchedule (ms: int) (callback: unit -> unit) : Pid =
+    spawn (fun () ->
         match Erlang.receive<TimerControl> ms with
         | Some Cancel -> ()
-        | None -> callback ()))
+        | None -> callback ())
 
-/// Cancel a scheduled timer.
-[<Emit("$0 ! cancel, ok")>]
-let timerCancel (timer: obj) : unit = nativeOnly
+/// Cancel a scheduled timer by sending the cancel atom to its process.
+let timerCancel (timer: Pid) : unit = Fable.Beam.Erlang.send timer (box Cancel)
 
 #endif

--- a/src/Fable.Actor/Types.fs
+++ b/src/Fable.Actor/Types.fs
@@ -3,8 +3,14 @@
 /// No platform code, no dependencies beyond Fable.Core.
 module Fable.Actor.Types
 
+open Fable.Core
+
 /// A reply channel that the receiver calls to send a response back to the caller.
 type ReplyChannel<'Reply> = { Reply: 'Reply -> unit }
+
+/// Opaque handle for a scheduled timer (erased to the platform-native handle).
+[<Erase>]
+type TimerHandle = TimerHandle of obj
 
 /// What the actor should do after handling a message.
 type Next<'State> =
@@ -25,5 +31,4 @@ type Directive =
     | Escalate
 
 /// Supervision strategy — consulted when a child crashes.
-type Strategy =
-    | OneForOne of decider: (exn -> Directive)
+type Strategy = OneForOne of decider: (exn -> Directive)


### PR DESCRIPTION
## Summary
- Bump Fable.Beam and Fable.Beam.Cowboy from 5.0.0-rc.14 to 5.0.0-rc.15
- Replace raw `[<Emit>]` atom literals with typed `binaryToAtom` calls (`Atom` instead of `obj`)
- Type timer internals as `Pid` and replace `timerCancel` Emit with typed `Erlang.send`
- Add erased `TimerHandle` type for cross-platform timer handle safety (replaces `obj`)

Related upstream PR: https://github.com/fable-compiler/Fable.Beam/pull/31

## Test plan
- [x] `dotnet build src/Fable.Actor` succeeds
- [ ] Verify timeflies-beam example builds
- [ ] Verify BEAM compilation and runtime behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)