### PR TITLE
feat!: bump Fable.Beam to 5.0.0-rc.22 and use RequireQualifiedAccess

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
     if: "startsWith(github.event.head_commit.message, 'chore: release ')"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v5

--- a/examples/timeflies-beam/src/Timeflies.fsproj
+++ b/examples/timeflies-beam/src/Timeflies.fsproj
@@ -8,7 +8,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../timeflies/src/Timeflies.Common.fsproj" />
-    <PackageReference Include="Fable.Beam" Version="5.0.0-rc.15" />
-    <PackageReference Include="Fable.Beam.Cowboy" Version="5.0.0-rc.15" />
+    <PackageReference Include="Fable.Beam" Version="5.0.0-rc.22" />
+    <PackageReference Include="Fable.Beam.Cowboy" Version="5.0.0-rc.22" />
   </ItemGroup>
 </Project>

--- a/src/Fable.Actor/Actor.fs
+++ b/src/Fable.Actor/Actor.fs
@@ -1,13 +1,12 @@
-/// Platform-independent Actor abstraction.
-///
-/// BEAM: actor { } is a CPS computation (no-op wrapper, BEAM processes block natively).
-/// Non-BEAM: actor { } delegates to async { }, Actor wraps MailboxProcessor.
-///
-/// Actor<'Msg> provides MailboxProcessor-compatible API:
-///   inbox.Receive() — get next message (inside body)
-///   actor.Post(msg)  — send a message (from outside)
-[<AutoOpen>]
-module Fable.Actor.Actor
+// Platform-independent Actor abstraction.
+//
+// BEAM: actor { } is a CPS computation (no-op wrapper, BEAM processes block natively).
+// Non-BEAM: actor { } delegates to async { }, Actor wraps MailboxProcessor.
+//
+// Actor<'Msg> provides MailboxProcessor-compatible API:
+//   inbox.Receive() — get next message (inside body)
+//   actor.Post(msg)  — send a message (from outside)
+namespace Fable.Actor
 
 open Fable.Actor.Types
 
@@ -17,7 +16,7 @@ open Fable.Actor.Types
 
 #if FABLE_COMPILER_BEAM
 
-open Fable.Beam.Erlang
+open Fable.Beam
 open Fable.Actor.Platform
 
 // === BEAM: CPS-based, native processes ===
@@ -90,189 +89,6 @@ type ActorBuilder() =
 
 #endif
 
-let actor = ActorBuilder()
-
-// ============================================================================
-// Core API
-// ============================================================================
-
-#if FABLE_COMPILER_BEAM
-
-/// Spawn an actor. Body receives inbox (self-reference) for Receive/Post.
-let spawn (body: Actor<'Msg> -> ActorOp<unit>) : Actor<'Msg> =
-    let rawPid =
-        Fable.Beam.Erlang.spawn (fun () ->
-            let me: Actor<'Msg> = { Pid = Fable.Beam.Erlang.self () }
-            (body me).Run(fun () -> ()))
-
-    { Pid = rawPid }
-
-/// Spawn a linked child actor (parent gets EXIT signal on crash).
-let spawnLinked (_parent: Actor<'ParentMsg>) (body: Actor<'Msg> -> ActorOp<unit>) : Actor<'Msg> =
-    let rawPid =
-        spawnLink (fun () ->
-            let me: Actor<'Msg> = { Pid = Fable.Beam.Erlang.self () }
-            (body me).Run(fun () -> ()))
-
-    { Pid = rawPid }
-
-/// Get own pid (only valid inside actor body).
-let self<'Msg> () : Actor<'Msg> = { Pid = Fable.Beam.Erlang.self () }
-
-/// Kill an actor and its linked children.
-let kill (actor: Actor<'Msg>) : unit = killProcess actor.Pid
-
-/// Enable supervision — child EXIT signals become messages.
-let trapExits () : unit = Platform.trapExits ()
-
-/// Format a crash reason as a string.
-let formatReason (reason: obj) : string = Platform.formatReason reason
-
-/// Send a message and await a reply (inside actor { }).
-let call (actor: Actor<'Msg * ReplyChannel<'Reply>>) (msg: 'Msg) : ActorOp<'Reply> = {
-    Run =
-        fun cont ->
-            let ref = makeRef ()
-            let callerPid = Fable.Beam.Erlang.self ()
-
-            let rc: ReplyChannel<'Reply> = {
-                Reply = fun reply -> sendReply callerPid ref reply
-            }
-
-            sendMsg actor.Pid (box (msg, rc))
-            cont (unbox (recvReply ref))
-}
-
-/// Send a message and await a reply with a timeout in milliseconds.
-/// Raises TimeoutException if no reply is received within the timeout.
-let callWithTimeout (timeout: int) (actor: Actor<'Msg * ReplyChannel<'Reply>>) (msg: 'Msg) : ActorOp<'Reply> = {
-    Run =
-        fun cont ->
-            let ref = makeRef ()
-            let callerPid = Fable.Beam.Erlang.self ()
-
-            let rc: ReplyChannel<'Reply> = {
-                Reply = fun reply -> sendReply callerPid ref reply
-            }
-
-            sendMsg actor.Pid (box (msg, rc))
-
-            match recvReplyWithTimeout ref timeout with
-            | Some reply -> cont (unbox<'Reply> reply)
-            | None -> raise (System.TimeoutException("Actor call timed out"))
-}
-
-/// Receive next message (free function).
-let receive<'Msg> () : ActorOp<'Msg> = {
-    Run = fun cont -> receiveMsg (fun raw -> cont (unbox<'Msg> raw))
-}
-
-#else
-
-/// Spawn an actor with an optional external cancellation token.
-/// When the external token is cancelled, the actor's CTS is also cancelled.
-let spawnWithToken (cancellationToken: System.Threading.CancellationToken) (body: Actor<'Msg> -> Async<unit>) : Actor<'Msg> =
-    let cts = new System.Threading.CancellationTokenSource()
-
-    cancellationToken.Register(fun () -> cts.Cancel())
-    |> ignore
-
-    let mutable inbox: Actor<'Msg> option = None
-
-    let mb =
-        MailboxProcessor.Start(fun mb ->
-            let actor = { Mb = mb; Cts = cts }
-            inbox <- Some actor
-            body actor)
-
-    match inbox with
-    | Some a -> a
-    | None -> { Mb = mb; Cts = cts }
-
-/// Spawn an actor. Body receives inbox (self-reference) for Receive/Post.
-let spawn (body: Actor<'Msg> -> Async<unit>) : Actor<'Msg> =
-    let cts = new System.Threading.CancellationTokenSource()
-    let mutable inbox: Actor<'Msg> option = None
-
-    let mb =
-        MailboxProcessor.Start(fun mb ->
-            let actor = { Mb = mb; Cts = cts }
-            inbox <- Some actor
-            body actor)
-
-    match inbox with
-    | Some a -> a
-    | None -> { Mb = mb; Cts = cts }
-
-/// Spawn a linked child actor. On crash, delivers ChildExited to parent.
-let spawnLinked (parent: Actor<'ParentMsg>) (body: Actor<'Msg> -> Async<unit>) : Actor<'Msg> =
-    let cts = new System.Threading.CancellationTokenSource()
-    let mutable inbox: Actor<'Msg> option = None
-
-    let mb =
-        MailboxProcessor.Start(fun mb ->
-            let actor = { Mb = mb; Cts = cts }
-            inbox <- Some actor
-
-            async {
-                try
-                    do! body actor
-                with ex ->
-                    parent.Post(unbox { Pid = box mb; Reason = box ex })
-            })
-
-    match inbox with
-    | Some a -> a
-    | None -> { Mb = mb; Cts = cts }
-
-/// Kill an actor — cancels its token and disposes the MailboxProcessor.
-let kill (actor: Actor<'Msg>) : unit =
-    actor.Cts.Cancel()
-    (actor.Mb :> System.IDisposable).Dispose()
-
-/// Enable supervision (stub on non-BEAM).
-let trapExits () : unit = ()
-
-/// Send a message and await a reply (inside actor { }).
-let call (target: Actor<'Msg * ReplyChannel<'Reply>>) (msg: 'Msg) : ActorOp<'Reply> =
-    actor {
-        let! reply = target.Mb.PostAndAsyncReply(fun rc -> (msg, { Reply = fun r -> rc.Reply(r) }))
-
-        return reply
-    }
-
-/// Send a message and await a reply with a timeout in milliseconds.
-/// Raises TimeoutException if no reply is received within the timeout.
-let callWithTimeout (timeout: int) (target: Actor<'Msg * ReplyChannel<'Reply>>) (msg: 'Msg) : ActorOp<'Reply> =
-    let mutable result: 'Reply option = None
-    let rc: ReplyChannel<'Reply> = { Reply = fun r -> result <- Some r }
-    target.Post((msg, rc))
-
-    let step = 5
-
-    let rec wait elapsed =
-        actor {
-            match result with
-            | Some r -> return r
-            | None ->
-                if elapsed >= timeout then
-                    raise (System.TimeoutException("Actor call timed out"))
-
-                do! Async.Sleep step
-                return! wait (elapsed + step)
-        }
-
-    wait 0
-
-/// Receive next message (free function, for backwards compatibility).
-let receive<'Msg> (inbox: Actor<'Msg>) : Async<'Msg> = inbox.Receive()
-
-#endif
-
-// ============================================================================
-// Supervision
-// ============================================================================
-
 /// A supervised child — wraps an actor ref with restart capability.
 type SupervisedChild<'ParentMsg, 'Msg> = {
     mutable Actor: Actor<'Msg>
@@ -280,160 +96,348 @@ type SupervisedChild<'ParentMsg, 'Msg> = {
     Strategy: Strategy
 }
 
+[<AutoOpen>]
+module ActorCE =
+    let actor = ActorBuilder()
+
+// ============================================================================
+// Core API
+// ============================================================================
+
+[<RequireQualifiedAccess>]
+module Actor =
+
 #if FABLE_COMPILER_BEAM
 
-/// Check if a message is a ChildExited notification.
-let tryAsChildExited (msg: obj) : ChildExited option =
-    if isChildExited msg then
-        Some(unbox<ChildExited> msg)
-    else
-        None
+    /// Spawn an actor. Body receives inbox (self-reference) for Receive/Post.
+    let spawn (body: Actor<'Msg> -> ActorOp<unit>) : Actor<'Msg> =
+        let rawPid =
+            Erlang.spawn (fun () ->
+                let me: Actor<'Msg> = { Pid = Erlang.self () }
+                (body me).Run(fun () -> ()))
 
-/// Spawn a supervised child actor. Retains the body for restart.
-let spawnSupervised
-    (parent: Actor<'ParentMsg>)
-    (strategy: Strategy)
-    (body: Actor<'Msg> -> ActorOp<unit>)
-    : SupervisedChild<'ParentMsg, 'Msg> =
-    let child = spawnLinked parent body
+        { Pid = rawPid }
 
-    {
-        Actor = child
-        Body = body
-        Strategy = strategy
+    /// Spawn a linked child actor (parent gets EXIT signal on crash).
+    let spawnLinked (_parent: Actor<'ParentMsg>) (body: Actor<'Msg> -> ActorOp<unit>) : Actor<'Msg> =
+        let rawPid =
+            Erlang.spawnLink (fun () ->
+                let me: Actor<'Msg> = { Pid = Erlang.self () }
+                (body me).Run(fun () -> ()))
+
+        { Pid = rawPid }
+
+    /// Get own pid (only valid inside actor body).
+    let self<'Msg> () : Actor<'Msg> = { Pid = Erlang.self () }
+
+    /// Kill an actor and its linked children.
+    let kill (actor: Actor<'Msg>) : unit = killProcess actor.Pid
+
+    /// Enable supervision — child EXIT signals become messages.
+    let trapExits () : unit = Platform.trapExits ()
+
+    /// Format a crash reason as a string.
+    let formatReason (reason: obj) : string = Platform.formatReason reason
+
+    /// Send a message and await a reply (inside actor { }).
+    let call (actor: Actor<'Msg * ReplyChannel<'Reply>>) (msg: 'Msg) : ActorOp<'Reply> = {
+        Run =
+            fun cont ->
+                let ref = Erlang.makeRef ()
+                let callerPid = Erlang.self ()
+
+                let rc: ReplyChannel<'Reply> = {
+                    Reply = fun reply -> sendReply callerPid ref reply
+                }
+
+                sendMsg actor.Pid (box (msg, rc))
+                cont (unbox (recvReply ref))
     }
 
-/// Handle a ChildExited event for a supervised child.
-/// Returns true if the child was restarted, false if stopped/not matching.
-/// Raises ProcessExitException if Escalate.
-let handleChildExit (parent: Actor<'ParentMsg>) (supervised: SupervisedChild<'ParentMsg, 'Msg>) (exited: ChildExited) : bool =
-    let (OneForOne decider) = supervised.Strategy
+    /// Send a message and await a reply with a timeout in milliseconds.
+    /// Raises TimeoutException if no reply is received within the timeout.
+    let callWithTimeout (timeout: int) (actor: Actor<'Msg * ReplyChannel<'Reply>>) (msg: 'Msg) : ActorOp<'Reply> = {
+        Run =
+            fun cont ->
+                let ref = Erlang.makeRef ()
+                let callerPid = Erlang.self ()
 
-    let ex =
-        match exited.Reason with
-        | :? exn as e -> e
-        | r -> ProcessExitException(sprintf "%A" r)
+                let rc: ReplyChannel<'Reply> = {
+                    Reply = fun reply -> sendReply callerPid ref reply
+                }
 
-    match decider ex with
-    | Directive.Stop -> false
-    | Directive.Escalate -> raise ex
-    | Directive.Restart ->
-        let newChild = spawnLinked parent supervised.Body
-        supervised.Actor <- newChild
-        true
+                sendMsg actor.Pid (box (msg, rc))
+
+                match recvReplyWithTimeout ref timeout with
+                | Some reply -> cont (unbox<'Reply> reply)
+                | None -> raise (System.TimeoutException("Actor call timed out"))
+    }
+
+    /// Receive next message (free function).
+    let receive<'Msg> () : ActorOp<'Msg> = {
+        Run = fun cont -> receiveMsg (fun raw -> cont (unbox<'Msg> raw))
+    }
 
 #else
 
-/// Check if a message is a ChildExited notification.
-let tryAsChildExited (msg: obj) : ChildExited option =
-    match msg with
-    | :? ChildExited as ce -> Some ce
-    | _ -> None
+    /// Spawn an actor with an optional external cancellation token.
+    /// When the external token is cancelled, the actor's CTS is also cancelled.
+    let spawnWithToken (cancellationToken: System.Threading.CancellationToken) (body: Actor<'Msg> -> Async<unit>) : Actor<'Msg> =
+        let cts = new System.Threading.CancellationTokenSource()
 
-/// Spawn a supervised child actor. Retains the body for restart.
-let spawnSupervised
-    (parent: Actor<'ParentMsg>)
-    (strategy: Strategy)
-    (body: Actor<'Msg> -> Async<unit>)
-    : SupervisedChild<'ParentMsg, 'Msg> =
-    let child = spawnLinked parent body
+        cancellationToken.Register(fun () -> cts.Cancel())
+        |> ignore
 
-    {
-        Actor = child
-        Body = body
-        Strategy = strategy
-    }
+        let mutable inbox: Actor<'Msg> option = None
 
-/// Handle a ChildExited event for a supervised child.
-/// Returns true if the child was restarted, false if stopped/not matching.
-/// Raises ProcessExitException if Escalate.
-let handleChildExit (parent: Actor<'ParentMsg>) (supervised: SupervisedChild<'ParentMsg, 'Msg>) (exited: ChildExited) : bool =
-    let (OneForOne decider) = supervised.Strategy
+        let mb =
+            MailboxProcessor.Start(fun mb ->
+                let actor = { Mb = mb; Cts = cts }
+                inbox <- Some actor
+                body actor)
 
-    let ex =
-        match exited.Reason with
-        | :? exn as e -> e
-        | r -> ProcessExitException(sprintf "%A" r)
+        match inbox with
+        | Some a -> a
+        | None -> { Mb = mb; Cts = cts }
 
-    match decider ex with
-    | Directive.Stop -> false
-    | Directive.Escalate -> raise ex
-    | Directive.Restart ->
-        let newChild = spawnLinked parent supervised.Body
-        supervised.Actor <- newChild
-        true
+    /// Spawn an actor. Body receives inbox (self-reference) for Receive/Post.
+    let spawn (body: Actor<'Msg> -> Async<unit>) : Actor<'Msg> =
+        let cts = new System.Threading.CancellationTokenSource()
+        let mutable inbox: Actor<'Msg> option = None
 
-#endif
+        let mb =
+            MailboxProcessor.Start(fun mb ->
+                let actor = { Mb = mb; Cts = cts }
+                inbox <- Some actor
+                body actor)
 
-// === Common API (both platforms) ===
+        match inbox with
+        | Some a -> a
+        | None -> { Mb = mb; Cts = cts }
 
-/// Send a message (fire and forget).
-let send (actor: Actor<'Msg>) (msg: 'Msg) : unit = actor.Post(msg)
+    /// Spawn a linked child actor. On crash, delivers ChildExited to parent.
+    let spawnLinked (parent: Actor<'ParentMsg>) (body: Actor<'Msg> -> Async<unit>) : Actor<'Msg> =
+        let cts = new System.Threading.CancellationTokenSource()
+        let mutable inbox: Actor<'Msg> option = None
 
-/// Fire-and-forget message to a call-capable actor (no-op reply channel).
-let cast (actor: Actor<'Msg * ReplyChannel<'Reply>>) (msg: 'Msg) : unit =
-    actor.Post((msg, { Reply = fun _ -> () }))
+        let mb =
+            MailboxProcessor.Start(fun mb ->
+                let actor = { Mb = mb; Cts = cts }
+                inbox <- Some actor
 
-/// Start a stateful actor with a message handler.
-let start (initialState: 'State) (handler: 'State -> 'Msg -> Next<'State>) : Actor<'Msg> =
-    let body (inbox: Actor<'Msg>) =
-        let rec loop state =
+                async {
+                    try
+                        do! body actor
+                    with ex ->
+                        parent.Post(unbox { Pid = box mb; Reason = box ex })
+                })
+
+        match inbox with
+        | Some a -> a
+        | None -> { Mb = mb; Cts = cts }
+
+    /// Kill an actor — cancels its token and disposes the MailboxProcessor.
+    let kill (actor: Actor<'Msg>) : unit =
+        actor.Cts.Cancel()
+        (actor.Mb :> System.IDisposable).Dispose()
+
+    /// Enable supervision (stub on non-BEAM).
+    let trapExits () : unit = ()
+
+    /// Send a message and await a reply (inside actor { }).
+    let call (target: Actor<'Msg * ReplyChannel<'Reply>>) (msg: 'Msg) : ActorOp<'Reply> =
+        actor {
+            let! reply = target.Mb.PostAndAsyncReply(fun rc -> (msg, { Reply = fun r -> rc.Reply(r) }))
+
+            return reply
+        }
+
+    /// Send a message and await a reply with a timeout in milliseconds.
+    /// Raises TimeoutException if no reply is received within the timeout.
+    let callWithTimeout (timeout: int) (target: Actor<'Msg * ReplyChannel<'Reply>>) (msg: 'Msg) : ActorOp<'Reply> =
+        let mutable result: 'Reply option = None
+        let rc: ReplyChannel<'Reply> = { Reply = fun r -> result <- Some r }
+        target.Post((msg, rc))
+
+        let step = 5
+
+        let rec wait elapsed =
             actor {
-                let! msg = inbox.Receive()
+                match result with
+                | Some r -> return r
+                | None ->
+                    if elapsed >= timeout then
+                        raise (System.TimeoutException("Actor call timed out"))
 
-                match handler state msg with
-                | Continue newState -> return! loop newState
-                | Stop -> ()
-                | StopAbnormal ex -> raise ex
+                    do! Async.Sleep step
+                    return! wait (elapsed + step)
             }
 
-        loop initialState
+        wait 0
+
+    /// Receive next message (free function, for backwards compatibility).
+    let receive<'Msg> (inbox: Actor<'Msg>) : Async<'Msg> = inbox.Receive()
+
+#endif
+
+    // ============================================================================
+    // Supervision
+    // ============================================================================
 
 #if FABLE_COMPILER_BEAM
-    let rawPid =
-        Fable.Beam.Erlang.spawn (fun () ->
-            let me: Actor<'Msg> = { Pid = Fable.Beam.Erlang.self () }
-            (body me).Run(fun () -> ()))
 
-    { Pid = rawPid }
+    /// Check if a message is a ChildExited notification.
+    let tryAsChildExited (msg: obj) : ChildExited option =
+        if isChildExited msg then
+            Some(unbox<ChildExited> msg)
+        else
+            None
+
+    /// Spawn a supervised child actor. Retains the body for restart.
+    let spawnSupervised
+        (parent: Actor<'ParentMsg>)
+        (strategy: Strategy)
+        (body: Actor<'Msg> -> ActorOp<unit>)
+        : SupervisedChild<'ParentMsg, 'Msg> =
+        let child = spawnLinked parent body
+
+        {
+            Actor = child
+            Body = body
+            Strategy = strategy
+        }
+
+    /// Handle a ChildExited event for a supervised child.
+    /// Returns true if the child was restarted, false if stopped/not matching.
+    /// Raises ProcessExitException if Escalate.
+    let handleChildExit (parent: Actor<'ParentMsg>) (supervised: SupervisedChild<'ParentMsg, 'Msg>) (exited: ChildExited) : bool =
+        let (OneForOne decider) = supervised.Strategy
+
+        let ex =
+            match exited.Reason with
+            | :? exn as e -> e
+            | r -> ProcessExitException(sprintf "%A" r)
+
+        match decider ex with
+        | Directive.Stop -> false
+        | Directive.Escalate -> raise ex
+        | Directive.Restart ->
+            let newChild = spawnLinked parent supervised.Body
+            supervised.Actor <- newChild
+            true
+
 #else
-    spawn body
+
+    /// Check if a message is a ChildExited notification.
+    let tryAsChildExited (msg: obj) : ChildExited option =
+        match msg with
+        | :? ChildExited as ce -> Some ce
+        | _ -> None
+
+    /// Spawn a supervised child actor. Retains the body for restart.
+    let spawnSupervised
+        (parent: Actor<'ParentMsg>)
+        (strategy: Strategy)
+        (body: Actor<'Msg> -> Async<unit>)
+        : SupervisedChild<'ParentMsg, 'Msg> =
+        let child = spawnLinked parent body
+
+        {
+            Actor = child
+            Body = body
+            Strategy = strategy
+        }
+
+    /// Handle a ChildExited event for a supervised child.
+    /// Returns true if the child was restarted, false if stopped/not matching.
+    /// Raises ProcessExitException if Escalate.
+    let handleChildExit (parent: Actor<'ParentMsg>) (supervised: SupervisedChild<'ParentMsg, 'Msg>) (exited: ChildExited) : bool =
+        let (OneForOne decider) = supervised.Strategy
+
+        let ex =
+            match exited.Reason with
+            | :? exn as e -> e
+            | r -> ProcessExitException(sprintf "%A" r)
+
+        match decider ex with
+        | Directive.Stop -> false
+        | Directive.Escalate -> raise ex
+        | Directive.Restart ->
+            let newChild = spawnLinked parent supervised.Body
+            supervised.Actor <- newChild
+            true
+
+#endif
+
+    // === Common API (both platforms) ===
+
+    /// Send a message (fire and forget).
+    let send (actor: Actor<'Msg>) (msg: 'Msg) : unit = actor.Post(msg)
+
+    /// Fire-and-forget message to a call-capable actor (no-op reply channel).
+    let cast (actor: Actor<'Msg * ReplyChannel<'Reply>>) (msg: 'Msg) : unit =
+        actor.Post((msg, { Reply = fun _ -> () }))
+
+    /// Start a stateful actor with a message handler.
+    let start (initialState: 'State) (handler: 'State -> 'Msg -> Next<'State>) : Actor<'Msg> =
+        let body (inbox: Actor<'Msg>) =
+            let rec loop state =
+                actor {
+                    let! msg = inbox.Receive()
+
+                    match handler state msg with
+                    | Continue newState -> return! loop newState
+                    | Stop -> ()
+                    | StopAbnormal ex -> raise ex
+                }
+
+            loop initialState
+
+#if FABLE_COMPILER_BEAM
+        let rawPid =
+            Erlang.spawn (fun () ->
+                let me: Actor<'Msg> = { Pid = Erlang.self () }
+                (body me).Run(fun () -> ()))
+
+        { Pid = rawPid }
+#else
+        spawn body
 #endif
 
 #if FABLE_COMPILER_BEAM
 
-/// Schedule a timer callback. Returns a typed handle for cancellation.
-let schedule (ms: int) (callback: unit -> unit) : TimerHandle =
-    TimerHandle(box (timerSchedule ms callback))
+    /// Schedule a timer callback. Returns a typed handle for cancellation.
+    let schedule (ms: int) (callback: unit -> unit) : TimerHandle =
+        TimerHandle(box (timerSchedule ms callback))
 
-/// Cancel a scheduled timer.
-let cancelTimer (TimerHandle handle: TimerHandle) : unit = timerCancel (unbox<Pid> handle)
+    /// Cancel a scheduled timer.
+    let cancelTimer (TimerHandle handle: TimerHandle) : unit = timerCancel (unbox<Pid> handle)
 
 #else
 
-/// Schedule a timer callback. Returns a typed handle for cancellation.
-let schedule (ms: int) (callback: unit -> unit) : TimerHandle =
-    let cts = new System.Threading.CancellationTokenSource()
+    /// Schedule a timer callback. Returns a typed handle for cancellation.
+    let schedule (ms: int) (callback: unit -> unit) : TimerHandle =
+        let cts = new System.Threading.CancellationTokenSource()
 
-    Async.StartImmediate(
-        async {
-            do! Async.Sleep ms
-            callback ()
-        },
-        cts.Token
-    )
+        Async.StartImmediate(
+            async {
+                do! Async.Sleep ms
+                callback ()
+            },
+            cts.Token
+        )
 
-    TimerHandle(box cts)
+        TimerHandle(box cts)
 
-/// Cancel a scheduled timer.
-let cancelTimer (TimerHandle handle: TimerHandle) : unit =
-    (unbox<System.Threading.CancellationTokenSource> handle).Cancel()
+    /// Cancel a scheduled timer.
+    let cancelTimer (TimerHandle handle: TimerHandle) : unit =
+        (unbox<System.Threading.CancellationTokenSource> handle).Cancel()
 
 #endif
 
-/// Extract the raw platform handle from an actor.
+    /// Extract the raw platform handle from an actor.
 #if FABLE_COMPILER_BEAM
-let pid (actor: Actor<'Msg>) : Pid = actor.Pid
+    let pid (actor: Actor<'Msg>) : Pid = actor.Pid
 #else
-let pid (actor: Actor<'Msg>) : obj = actor.Pid
+    let pid (actor: Actor<'Msg>) : obj = actor.Pid
 #endif

--- a/src/Fable.Actor/Fable.Actor.fsproj
+++ b/src/Fable.Actor/Fable.Actor.fsproj
@@ -22,7 +22,7 @@
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Fable.Beam" Version="5.0.0-rc.15" />
+    <PackageReference Include="Fable.Beam" Version="5.0.0-rc.22" />
     <PackageReference Include="Fable.Core" Version="5.0.0-rc.1" />
   </ItemGroup>
 </Project>

--- a/src/Fable.Actor/Platform.fs
+++ b/src/Fable.Actor/Platform.fs
@@ -9,23 +9,23 @@ module Fable.Actor.Platform
 open Fable.Core
 open Fable.Core.BeamInterop
 open Fable.Actor.Types
-open Fable.Beam.Erlang
+open Fable.Beam
 
 // ============================================================================
 // Atom literals
 // ============================================================================
 
-let private atomKill: Atom = binaryToAtom "kill"
-let private atomNormal: Atom = binaryToAtom "normal"
+let private atomKill: Atom = Erlang.binaryToAtom "kill"
+let private atomNormal: Atom = Erlang.binaryToAtom "normal"
 
 // ============================================================================
 // Process helpers (use Fable.Beam.Erlang with actor-specific atoms)
 // ============================================================================
 
-let killProcess (pid: Pid) : unit = exitPid pid atomKill
-let exitNormal () : unit = exit atomNormal
-let trapExits () : unit = trapExit () |> ignore
-let formatReason (reason: obj) : string = formatTerm reason
+let killProcess (pid: Pid) : unit = Erlang.exitPid pid atomKill
+let exitNormal () : unit = Erlang.exit atomNormal
+let trapExits () : unit = Erlang.trapExit () |> ignore
+let formatReason (reason: obj) : string = Erlang.formatTerm reason
 
 // ============================================================================
 // Internal message protocol
@@ -65,7 +65,7 @@ let rec receiveMsg (cont: obj -> unit) : unit =
     | ActorTimer(_, callback) ->
         callback (box ())
         receiveMsg cont
-    | Exit(_, reason) when exactEquals reason atomNormal -> receiveMsg cont
+    | Exit(_, reason) when Erlang.exactEquals reason atomNormal -> receiveMsg cont
     | Exit(pid, reason) -> cont (box ({ Pid = box pid; Reason = reason }: ChildExited))
 
 /// Blocking selective receive for a reply matching a specific ref.
@@ -95,12 +95,12 @@ type private TimerControl = | [<CompiledName("cancel")>] Cancel
 /// Schedule a callback after ms milliseconds.
 /// Returns the timer process pid for cancellation.
 let timerSchedule (ms: int) (callback: unit -> unit) : Pid =
-    spawn (fun () ->
+    Erlang.spawn (fun () ->
         match Erlang.receive<TimerControl> ms with
         | Some Cancel -> ()
         | None -> callback ())
 
 /// Cancel a scheduled timer by sending the cancel atom to its process.
-let timerCancel (timer: Pid) : unit = Fable.Beam.Erlang.send timer (box Cancel)
+let timerCancel (timer: Pid) : unit = Erlang.send timer (box Cancel)
 
 #endif

--- a/test/ActorTest.fs
+++ b/test/ActorTest.fs
@@ -13,7 +13,7 @@ open Fable.Actor.TestUtils
 let actor_empty_test () =
     actor {
         let _a: Actor<string> =
-            spawn (fun _inbox -> actor { return () })
+            Actor.spawn (fun _inbox -> actor { return () })
 
         do! sleep 10
         shouldBeTrue true
@@ -27,16 +27,16 @@ type SingleMsg =
 let actor_single_receive_test () =
     actor {
         let a =
-            start "" (fun state (msg, rc) ->
+            Actor.start "" (fun state (msg, rc) ->
                 match msg with
                 | SetValue s -> Continue s
                 | GetValue ->
                     rc.Reply state
                     Continue state)
 
-        cast a (SetValue "hello")
+        Actor.cast a (SetValue "hello")
         do! sleep 10
-        let! got = call a GetValue
+        let! got = Actor.call a GetValue
         shouldEqual "hello" got
     }
 
@@ -48,18 +48,18 @@ type CollectIntMsg =
 let actor_multiple_receive_test () =
     actor {
         let a =
-            start [] (fun items (msg, rc) ->
+            Actor.start [] (fun items (msg, rc) ->
                 match msg with
                 | AddItem n -> Continue(items @ [ n ])
                 | GetItems ->
                     rc.Reply items
                     Continue items)
 
-        cast a (AddItem 1)
-        cast a (AddItem 2)
-        cast a (AddItem 3)
+        Actor.cast a (AddItem 1)
+        Actor.cast a (AddItem 2)
+        Actor.cast a (AddItem 3)
         do! sleep 10
-        let! items = call a GetItems
+        let! items = Actor.call a GetItems
         shouldEqual [ 1; 2; 3 ] items
     }
 
@@ -71,7 +71,7 @@ type PostMsg =
 let actor_post_test () =
     actor {
         let a =
-            start 0 (fun state (msg, rc) ->
+            Actor.start 0 (fun state (msg, rc) ->
                 match msg with
                 | SetInt n -> Continue n
                 | GetInt ->
@@ -80,7 +80,7 @@ let actor_post_test () =
 
         a.Post((SetInt 42, { Reply = fun _ -> () }))
         do! sleep 10
-        let! got = call a GetInt
+        let! got = Actor.call a GetInt
         shouldEqual 42 got
     }
 
@@ -97,7 +97,7 @@ type CounterMsg =
 let actor_start_basic_test () =
     actor {
         let counter =
-            start 0 (fun count (msg, rc) ->
+            Actor.start 0 (fun count (msg, rc) ->
                 match msg with
                 | Increment -> Continue(count + 1)
                 | Decrement -> Continue(count - 1)
@@ -105,14 +105,14 @@ let actor_start_basic_test () =
                     rc.Reply count
                     Continue count)
 
-        cast counter Increment
-        cast counter Increment
-        cast counter Increment
-        cast counter Decrement
+        Actor.cast counter Increment
+        Actor.cast counter Increment
+        Actor.cast counter Increment
+        Actor.cast counter Decrement
 
         do! sleep 10
 
-        let! count = call counter GetCount
+        let! count = Actor.call counter GetCount
         shouldEqual 2 count
     }
 
@@ -124,20 +124,20 @@ type Command =
 let actor_start_stop_test () =
     actor {
         let counter =
-            start 0 (fun count (msg, rc) ->
+            Actor.start 0 (fun count (msg, rc) ->
                 match msg with
                 | Add _ -> Continue(count + 1)
                 | Done ->
                     rc.Reply count
                     Stop)
 
-        cast counter (Add 1)
-        cast counter (Add 1)
-        cast counter (Add 1)
+        Actor.cast counter (Add 1)
+        Actor.cast counter (Add 1)
+        Actor.cast counter (Add 1)
 
         do! sleep 10
 
-        let! count = call counter Done
+        let! count = Actor.call counter Done
         shouldEqual 3 count
     }
 
@@ -149,7 +149,7 @@ let actor_start_stop_test () =
 let actor_call_reply_test () =
     actor {
         let counter =
-            start 0 (fun count (msg, rc) ->
+            Actor.start 0 (fun count (msg, rc) ->
                 match msg with
                 | Increment -> Continue(count + 1)
                 | Decrement -> Continue(count - 1)
@@ -157,13 +157,14 @@ let actor_call_reply_test () =
                     rc.Reply count
                     Continue count)
 
-        cast counter Increment
-        cast counter Increment
-        cast counter Increment
+        Actor.cast counter Increment
+        Actor.cast counter Increment
+        Actor.cast counter Increment
+
 
         do! sleep 10
 
-        let! count = call counter GetCount
+        let! count = Actor.call counter GetCount
         shouldEqual 3 count
     }
 
@@ -171,7 +172,7 @@ let actor_call_reply_test () =
 let actor_multiple_calls_test () =
     actor {
         let counter =
-            start 0 (fun count (msg, rc) ->
+            Actor.start 0 (fun count (msg, rc) ->
                 match msg with
                 | Increment -> Continue(count + 1)
                 | Decrement -> Continue(count - 1)
@@ -179,15 +180,15 @@ let actor_multiple_calls_test () =
                     rc.Reply count
                     Continue count)
 
-        cast counter Increment
+        Actor.cast counter Increment
         do! sleep 10
-        let! c1 = call counter GetCount
+        let! c1 = Actor.call counter GetCount
         shouldEqual 1 c1
 
-        cast counter Increment
-        cast counter Increment
+        Actor.cast counter Increment
+        Actor.cast counter Increment
         do! sleep 10
-        let! c2 = call counter GetCount
+        let! c2 = Actor.call counter GetCount
         shouldEqual 3 c2
     }
 
@@ -203,7 +204,7 @@ type CollectorMsg<'T> =
 let actor_spawn_send_test () =
     actor {
         let collector =
-            start [] (fun results (msg, rc) ->
+            Actor.start [] (fun results (msg, rc) ->
                 match msg with
                 | Collect x -> Continue(results @ [ x ])
                 | GetResults ->
@@ -211,14 +212,14 @@ let actor_spawn_send_test () =
                     Continue results)
 
         let _worker: Actor<string> =
-            spawn (fun _inbox ->
-                cast collector (Collect "hello")
-                cast collector (Collect "world")
+            Actor.spawn (fun _inbox ->
+                Actor.cast collector (Collect "hello")
+                Actor.cast collector (Collect "world")
                 actor { return () })
 
         do! sleep 50
 
-        let! results = call collector GetResults
+        let! results = Actor.call collector GetResults
         shouldEqual [ "hello"; "world" ] results
     }
 
@@ -226,7 +227,7 @@ let actor_spawn_send_test () =
 let actor_spawn_receive_forward_test () =
     actor {
         let collector =
-            start [] (fun results (msg, rc) ->
+            Actor.start [] (fun results (msg, rc) ->
                 match msg with
                 | Collect x -> Continue(results @ [ x ])
                 | GetResults ->
@@ -234,23 +235,23 @@ let actor_spawn_receive_forward_test () =
                     Continue results)
 
         let doubler: Actor<int> =
-            spawn (fun inbox ->
+            Actor.spawn (fun inbox ->
                 let rec loop () =
                     actor {
                         let! n = inbox.Receive()
-                        cast collector (Collect(n * 2))
+                        Actor.cast collector (Collect(n * 2))
                         return! loop ()
                     }
 
                 loop ())
 
-        send doubler 1
-        send doubler 2
-        send doubler 3
+        Actor.send doubler 1
+        Actor.send doubler 2
+        Actor.send doubler 3
 
         do! sleep 50
 
-        let! results = call collector GetResults
+        let! results = Actor.call collector GetResults
         shouldEqual [ 2; 4; 6 ] results
     }
 
@@ -258,7 +259,7 @@ let actor_spawn_receive_forward_test () =
 let actor_async_work_test () =
     actor {
         let worker: Actor<unit * ReplyChannel<string>> =
-            spawn (fun inbox ->
+            Actor.spawn (fun inbox ->
                 let rec loop () =
                     actor {
                         let! (), rc = inbox.Receive()
@@ -269,7 +270,7 @@ let actor_async_work_test () =
 
                 loop ())
 
-        let! result = call worker ()
+        let! result = Actor.call worker ()
         shouldEqual "done" result
     }
 
@@ -285,20 +286,20 @@ type TimerMsg =
 let actor_schedule_test () =
     actor {
         let ticker =
-            start 0 (fun count (msg, rc) ->
+            Actor.start 0 (fun count (msg, rc) ->
                 match msg with
                 | Tick -> Continue(count + 1)
                 | GetTicks ->
                     rc.Reply count
                     Continue count)
 
-        schedule 10 (fun () -> cast ticker Tick) |> ignore
-        schedule 20 (fun () -> cast ticker Tick) |> ignore
-        schedule 30 (fun () -> cast ticker Tick) |> ignore
+        Actor.schedule 10 (fun () -> Actor.cast ticker Tick) |> ignore
+        Actor.schedule 20 (fun () -> Actor.cast ticker Tick) |> ignore
+        Actor.schedule 30 (fun () -> Actor.cast ticker Tick) |> ignore
 
         do! sleep 100
 
-        let! ticks = call ticker GetTicks
+        let! ticks = Actor.call ticker GetTicks
         shouldEqual 3 ticks
     }
 
@@ -310,11 +311,11 @@ let actor_schedule_test () =
 let actor_linked_crash_test () =
     actor {
         let supervisor =
-            spawn (fun inbox ->
-                trapExits ()
+            Actor.spawn (fun inbox ->
+                Actor.trapExits ()
 
                 let child: Actor<string> =
-                    spawnLinked inbox (fun childInbox ->
+                    Actor.spawnLinked inbox (fun childInbox ->
                         let rec loop () =
                             actor {
                                 let! _msg = childInbox.Receive()
@@ -325,7 +326,7 @@ let actor_linked_crash_test () =
                         loop ())
 
                 // Send a message to make the child crash
-                send child "boom"
+                Actor.send child "boom"
 
                 // Receive the EXIT signal
                 let rec loop (crashCount: int) =
@@ -348,7 +349,7 @@ let actor_linked_crash_test () =
 /// A reporter actor for cross-process state sharing on BEAM.
 /// Set via cast (Some value), query via call None.
 let reporter initial =
-    start initial (fun state (msg, rc) ->
+    Actor.start initial (fun state (msg, rc) ->
         match msg with
         | Some v -> Continue v
         | None -> rc.Reply state; Continue state)
@@ -359,11 +360,11 @@ let actor_supervised_restart_test () =
         let restarts = reporter 0
 
         let _parent: Actor<obj> =
-            spawn (fun inbox ->
-                trapExits ()
+            Actor.spawn (fun inbox ->
+                Actor.trapExits ()
 
                 let child =
-                    spawnSupervised inbox (OneForOne(fun _ex -> Directive.Restart)) (fun childInbox ->
+                    Actor.spawnSupervised inbox (OneForOne(fun _ex -> Directive.Restart)) (fun childInbox ->
                         let rec loop () =
                             actor {
                                 let! msg = childInbox.Receive()
@@ -376,17 +377,17 @@ let actor_supervised_restart_test () =
 
                         loop ())
 
-                send child.Actor "crash"
+                Actor.send child.Actor "crash"
 
                 let rec loop restartCount =
                     actor {
                         let! msg = inbox.Receive()
 
-                        match tryAsChildExited msg with
+                        match Actor.tryAsChildExited msg with
                         | Some exited ->
-                            let restarted = handleChildExit inbox child exited
+                            let restarted = Actor.handleChildExit inbox child exited
                             let newCount = if restarted then restartCount + 1 else restartCount
-                            cast restarts (Some newCount)
+                            Actor.cast restarts (Some newCount)
                             return! loop newCount
                         | None -> return! loop restartCount
                     }
@@ -394,7 +395,7 @@ let actor_supervised_restart_test () =
                 loop 0)
 
         do! sleep 200
-        let! count = call restarts None
+        let! count = Actor.call restarts None
         shouldBeTrue (count >= 1)
     }
 
@@ -404,11 +405,11 @@ let actor_supervised_stop_test () =
         let flag = reporter false
 
         let _parent: Actor<obj> =
-            spawn (fun inbox ->
-                trapExits ()
+            Actor.spawn (fun inbox ->
+                Actor.trapExits ()
 
                 let child =
-                    spawnSupervised inbox (OneForOne(fun _ex -> Directive.Stop)) (fun childInbox ->
+                    Actor.spawnSupervised inbox (OneForOne(fun _ex -> Directive.Stop)) (fun childInbox ->
                         let rec loop () =
                             actor {
                                 let! _msg = childInbox.Receive()
@@ -418,16 +419,16 @@ let actor_supervised_stop_test () =
 
                         loop ())
 
-                send child.Actor "boom"
+                Actor.send child.Actor "boom"
 
                 let rec loop () =
                     actor {
                         let! msg = inbox.Receive()
 
-                        match tryAsChildExited msg with
+                        match Actor.tryAsChildExited msg with
                         | Some exited ->
-                            let restarted = handleChildExit inbox child exited
-                            if not restarted then cast flag (Some true)
+                            let restarted = Actor.handleChildExit inbox child exited
+                            if not restarted then Actor.cast flag (Some true)
                         | None -> ()
 
                         return! loop ()
@@ -436,7 +437,7 @@ let actor_supervised_stop_test () =
                 loop ())
 
         do! sleep 200
-        let! stopped = call flag None
+        let! stopped = Actor.call flag None
         shouldBeTrue stopped
     }
 
@@ -450,11 +451,11 @@ let actor_stop_abnormal_test () =
         let flag = reporter false
 
         let _parent: Actor<obj> =
-            spawn (fun inbox ->
-                trapExits ()
+            Actor.spawn (fun inbox ->
+                Actor.trapExits ()
 
                 let stoppingChild =
-                    spawnSupervised inbox (OneForOne(fun _ex -> Directive.Stop)) (fun childInbox ->
+                    Actor.spawnSupervised inbox (OneForOne(fun _ex -> Directive.Stop)) (fun childInbox ->
                         let rec loop () =
                             actor {
                                 let! msg = childInbox.Receive()
@@ -467,16 +468,16 @@ let actor_stop_abnormal_test () =
 
                         loop ())
 
-                send stoppingChild.Actor "stop-abnormal"
+                Actor.send stoppingChild.Actor "stop-abnormal"
 
                 let rec loop () =
                     actor {
                         let! msg = inbox.Receive()
 
-                        match tryAsChildExited msg with
+                        match Actor.tryAsChildExited msg with
                         | Some exited ->
-                            handleChildExit inbox stoppingChild exited |> ignore
-                            cast flag (Some true)
+                            Actor.handleChildExit inbox stoppingChild exited |> ignore
+                            Actor.cast flag (Some true)
                         | None -> ()
 
                         return! loop ()
@@ -485,7 +486,7 @@ let actor_stop_abnormal_test () =
                 loop ())
 
         do! sleep 200
-        let! gotExit = call flag None
+        let! gotExit = Actor.call flag None
         shouldBeTrue gotExit
     }
 
@@ -495,11 +496,11 @@ let actor_start_stop_abnormal_test () =
         let flag = reporter false
 
         let _parent: Actor<obj> =
-            spawn (fun inbox ->
-                trapExits ()
+            Actor.spawn (fun inbox ->
+                Actor.trapExits ()
 
                 let child =
-                    spawnSupervised inbox (OneForOne(fun _ex -> Directive.Stop)) (fun childInbox ->
+                    Actor.spawnSupervised inbox (OneForOne(fun _ex -> Directive.Stop)) (fun childInbox ->
                         let rec loop (state: int) =
                             actor {
                                 let! msg = childInbox.Receive()
@@ -511,16 +512,16 @@ let actor_start_stop_abnormal_test () =
 
                         loop 0)
 
-                send child.Actor "fail"
+                Actor.send child.Actor "fail"
 
                 let rec loop () =
                     actor {
                         let! msg = inbox.Receive()
 
-                        match tryAsChildExited msg with
+                        match Actor.tryAsChildExited msg with
                         | Some exited ->
-                            handleChildExit inbox child exited |> ignore
-                            cast flag (Some true)
+                            Actor.handleChildExit inbox child exited |> ignore
+                            Actor.cast flag (Some true)
                         | None -> ()
 
                         return! loop ()
@@ -529,7 +530,7 @@ let actor_start_stop_abnormal_test () =
                 loop ())
 
         do! sleep 200
-        let! gotExit = call flag None
+        let! gotExit = Actor.call flag None
         shouldBeTrue gotExit
     }
 
@@ -539,11 +540,11 @@ let actor_start_handler_stop_abnormal_test () =
         let flag = reporter false
 
         let _parent: Actor<obj> =
-            spawn (fun inbox ->
-                trapExits ()
+            Actor.spawn (fun inbox ->
+                Actor.trapExits ()
 
                 let child =
-                    spawnSupervised inbox (OneForOne(fun _ex -> Directive.Restart)) (fun childInbox ->
+                    Actor.spawnSupervised inbox (OneForOne(fun _ex -> Directive.Restart)) (fun childInbox ->
                         let handler state msg =
                             match msg with
                             | "crash" -> StopAbnormal(ProcessExitException "handler decided to crash")
@@ -561,16 +562,16 @@ let actor_start_handler_stop_abnormal_test () =
 
                         loop 0)
 
-                send child.Actor "crash"
+                Actor.send child.Actor "crash"
 
                 let rec loop () =
                     actor {
                         let! msg = inbox.Receive()
 
-                        match tryAsChildExited msg with
+                        match Actor.tryAsChildExited msg with
                         | Some exited ->
-                            handleChildExit inbox child exited |> ignore
-                            cast flag (Some true)
+                            Actor.handleChildExit inbox child exited |> ignore
+                            Actor.cast flag (Some true)
                         | None -> ()
 
                         return! loop ()
@@ -579,7 +580,7 @@ let actor_start_handler_stop_abnormal_test () =
                 loop ())
 
         do! sleep 200
-        let! gotExit = call flag None
+        let! gotExit = Actor.call flag None
         shouldBeTrue gotExit
     }
 
@@ -595,7 +596,7 @@ type TimeoutMsg =
 let actor_call_with_timeout_success_test () =
     actor {
         let worker =
-            start () (fun _state (msg, rc) ->
+            Actor.start () (fun _state (msg, rc) ->
                 match msg with
                 | Fast ->
                     rc.Reply "fast"
@@ -604,7 +605,7 @@ let actor_call_with_timeout_success_test () =
                     rc.Reply "slow"
                     Continue())
 
-        let! result = callWithTimeout 1000 worker Fast
+        let! result = Actor.callWithTimeout 1000 worker Fast
         shouldEqual "fast" result
     }
 
@@ -612,7 +613,7 @@ let actor_call_with_timeout_success_test () =
 let actor_call_with_timeout_expires_test () =
     actor {
         let worker: Actor<unit * ReplyChannel<string>> =
-            spawn (fun inbox ->
+            Actor.spawn (fun inbox ->
                 let rec loop () =
                     actor {
                         let! (), _rc = inbox.Receive()
@@ -626,7 +627,7 @@ let actor_call_with_timeout_expires_test () =
         let mutable timedOut = false
 
         try
-            let! _result = callWithTimeout 50 worker ()
+            let! _result = Actor.callWithTimeout 50 worker ()
             ()
         with :? System.TimeoutException ->
             timedOut <- true
@@ -644,7 +645,7 @@ let actor_kill_test () =
         let mutable received = false
 
         let target: Actor<string> =
-            spawn (fun inbox ->
+            Actor.spawn (fun inbox ->
                 let rec loop () =
                     actor {
                         let! _msg = inbox.Receive()
@@ -654,8 +655,8 @@ let actor_kill_test () =
 
                 loop ())
 
-        kill target
-        send target "should not arrive"
+        Actor.kill target
+        Actor.send target "should not arrive"
         do! sleep 50
 
         shouldBeFalse received


### PR DESCRIPTION
## Summary
- Bump Fable.Beam from 5.0.0-rc.15 to 5.0.0-rc.22 (types moved to `Fable.Beam` namespace)
- Qualify all `Erlang` module calls (`open Fable.Beam` instead of `open Fable.Beam.Erlang`) to avoid naming conflict with our Actor module
- Restructure Actor.fs per [F# component design guidelines](https://learn.microsoft.com/en-us/dotnet/fsharp/style-guide/component-design-guidelines): types at namespace level, functions in `[<RequireQualifiedAccess>] module Actor`

API is now `Actor.spawn`, `Actor.send`, `Actor.call` etc. The `actor { }` CE builder remains unqualified via `[<AutoOpen>]`.

## Test plan
- [x] `dotnet build src/Fable.Actor` passes
- [x] `dotnet run --project test/Test.fsproj` — 21/21 tests pass
- [x] `dotnet fantomas src/` — no formatting changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)