### PR TITLE
chore: add shipit-pr job to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,9 +6,35 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
-  publish:
+  shipit-pr:
+    name: ShipIt - Pull Request
+    runs-on: ubuntu-latest
+    if: "!startsWith(github.event.head_commit.message, 'chore: release ')"
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.x
+
+      - name: Install tools
+        run: dotnet tool restore
+
+      - name: ShipIt (Pull Request)
+        run: dotnet shipit --pre-release rc
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release:
+    name: Release
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: "startsWith(github.event.head_commit.message, 'chore: release ')"
@@ -24,27 +50,12 @@ jobs:
       - name: Install just
         uses: extractions/setup-just@v3
 
-      - name: Extract version
-        id: version
-        run: |
-          MESSAGE="${{ github.event.head_commit.message }}"
-          VERSION="${MESSAGE#chore: release }"
-          VERSION="${VERSION%% *}"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
-
-      - name: Restore dependencies
+      - name: Install tools
         run: |
           dotnet tool restore
           dotnet restore src/Fable.Actor
 
-      - name: Pack NuGet
-        run: just pack-version ${{ steps.version.outputs.version }}
-
-      - name: Push NuGet
-        run: dotnet nuget push 'src/**/Release/*.nupkg' -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_API_KEY }}
-
-      - name: Create GitHub Release
-        run: gh release create ${{ steps.version.outputs.tag }} --title "${{ steps.version.outputs.version }}" --generate-notes || echo "Release already exists"
+      - name: Build, pack and push
+        run: just release
         env:
-          GH_TOKEN: ${{ github.token }}
+          NUGET_KEY: ${{ secrets.NUGET_API_KEY }}

--- a/justfile
+++ b/justfile
@@ -52,6 +52,10 @@ pack:
 pack-version version:
     dotnet pack {{src_path}} -c Release -p:PackageVersion={{version}} -p:InformationalVersion={{version}}
 
+# Release: pack and push to NuGet
+release: pack
+    dotnet nuget push 'src/**/Release/*.nupkg' -s https://api.nuget.org/v3/index.json -k $NUGET_KEY
+
 # Run EasyBuild.ShipIt for release management
 shipit *args:
     dotnet shipit --pre-release rc {{args}}


### PR DESCRIPTION
## Summary
- Add `shipit-pr` job to create release PRs automatically on every push to main (aligns with Fable.Beam workflow)
- Add `release` recipe to justfile (pack + push to NuGet)
- Simplify release job to use `just release`
- Add `pull-requests: write` permission for ShipIt

## Test plan
- [ ] Verify ShipIt PR job triggers on next push to main
- [ ] Verify release job still works on `chore: release` commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)