### PR TITLE
fix: extract version from CHANGELOG.md in pack recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -43,10 +43,12 @@ all: check build
 
 # --- Packaging ---
 
-# Create NuGet package
+# Create NuGet package with version from CHANGELOG.md
 pack:
-    dotnet build {{src_path}}
-    dotnet pack {{src_path}} -c Release
+    #!/usr/bin/env bash
+    set -euo pipefail
+    VERSION=$(grep -m1 '^## ' CHANGELOG.md | sed 's/^## \([^ ]*\).*/\1/')
+    dotnet pack {{src_path}} -c Release -p:PackageVersion=$VERSION -p:InformationalVersion=$VERSION
 
 # Create NuGet package with specific version (used in CI)
 pack-version version:


### PR DESCRIPTION
## Summary
- Fix `pack` recipe to extract version from `CHANGELOG.md` instead of using default project version (1.0.0)
- Aligns with Fable.Beam's approach

This caused a `1.0.0` package to be published to NuGet. The bad package should be unlisted on nuget.org.

## Test plan
- [ ] `just pack` produces a package with the correct version from CHANGELOG.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)