### PR TITLE
feat!: bump Fable.Beam to 5.0.0-rc.27 and adopt typed Pid/Ref

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "fable": {
-      "version": "5.0.0-rc.5",
+      "version": "5.0.0",
       "commands": [
         "fable"
       ],
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "easybuild.shipit": {
-      "version": "2.0.0",
+      "version": "2.3.0",
       "commands": [
         "shipit"
       ],

--- a/examples/timeflies-beam/src/Timeflies.fsproj
+++ b/examples/timeflies-beam/src/Timeflies.fsproj
@@ -8,7 +8,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../timeflies/src/Timeflies.Common.fsproj" />
-    <PackageReference Include="Fable.Beam" Version="5.0.0-rc.22" />
-    <PackageReference Include="Fable.Beam.Cowboy" Version="5.0.0-rc.22" />
+    <PackageReference Include="Fable.Beam" Version="5.0.0-rc.27" />
+    <PackageReference Include="Fable.Beam.Cowboy" Version="5.0.0-rc.23" />
   </ItemGroup>
 </Project>

--- a/examples/timeflies-js/src/Timeflies.Js.fsproj
+++ b/examples/timeflies-js/src/Timeflies.Js.fsproj
@@ -9,7 +9,7 @@
     <ProjectReference Include="../../timeflies/src/Timeflies.Common.fsproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Fable.Core" Version="5.0.0-rc.1" />
+    <PackageReference Include="Fable.Core" Version="5.0.0" />
     <PackageReference Include="Feliz" Version="3.2.0" />
   </ItemGroup>
 </Project>

--- a/examples/timeflies-python/src/Timeflies.Python.fsproj
+++ b/examples/timeflies-python/src/Timeflies.Python.fsproj
@@ -10,7 +10,7 @@
     <ProjectReference Include="../../timeflies/src/Timeflies.Common.fsproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Fable.Core" Version="5.0.0-rc.1" />
-    <PackageReference Include="Fable.Python" Version="5.0.0-rc.2" />
+    <PackageReference Include="Fable.Core" Version="5.0.0" />
+    <PackageReference Include="Fable.Python" Version="5.0.0" />
   </ItemGroup>
 </Project>

--- a/justfile
+++ b/justfile
@@ -32,7 +32,7 @@ check:
 
 # Format source files
 format:
-    dotnet fantomas src -r
+    dotnet fantomas src
 
 # Setup tooling
 restore:

--- a/src/Fable.Actor/Actor.fs
+++ b/src/Fable.Actor/Actor.fs
@@ -24,14 +24,14 @@ open Fable.Actor.Platform
 type ActorOp<'T> = { Run: ('T -> unit) -> unit }
 
 type Actor<'Msg> = {
-    Pid: Pid
+    Pid: Pid<'Msg>
 } with
 
     member _.Receive() : ActorOp<'Msg> = {
         Run = fun cont -> receiveMsg (fun raw -> cont (unbox<'Msg> raw))
     }
 
-    member this.Post(msg: 'Msg) = sendMsg this.Pid (box msg)
+    member this.Post(msg: 'Msg) = sendMsg this.Pid msg
 
 type ActorBuilder() =
     member _.Bind(op: ActorOp<'T>, f: 'T -> ActorOp<'U>) : ActorOp<'U> = {
@@ -150,8 +150,8 @@ module Actor =
                     Reply = fun reply -> sendReply callerPid ref reply
                 }
 
-                sendMsg actor.Pid (box (msg, rc))
-                cont (unbox (recvReply ref))
+                sendMsg actor.Pid (msg, rc)
+                cont (recvReply ref)
     }
 
     /// Send a message and await a reply with a timeout in milliseconds.
@@ -166,10 +166,10 @@ module Actor =
                     Reply = fun reply -> sendReply callerPid ref reply
                 }
 
-                sendMsg actor.Pid (box (msg, rc))
+                sendMsg actor.Pid (msg, rc)
 
                 match recvReplyWithTimeout ref timeout with
-                | Some reply -> cont (unbox<'Reply> reply)
+                | Some reply -> cont reply
                 | None -> raise (System.TimeoutException("Actor call timed out"))
     }
 
@@ -407,11 +407,10 @@ module Actor =
 #if FABLE_COMPILER_BEAM
 
     /// Schedule a timer callback. Returns a typed handle for cancellation.
-    let schedule (ms: int) (callback: unit -> unit) : TimerHandle =
-        TimerHandle(box (timerSchedule ms callback))
+    let schedule (ms: int) (callback: unit -> unit) : TimerHandle = TimerHandle(timerSchedule ms callback)
 
     /// Cancel a scheduled timer.
-    let cancelTimer (TimerHandle handle: TimerHandle) : unit = timerCancel (unbox<Pid> handle)
+    let cancelTimer (TimerHandle handle: TimerHandle) : unit = timerCancel handle
 
 #else
 
@@ -437,7 +436,7 @@ module Actor =
 
     /// Extract the raw platform handle from an actor.
 #if FABLE_COMPILER_BEAM
-    let pid (actor: Actor<'Msg>) : Pid = actor.Pid
+    let pid (actor: Actor<'Msg>) : Pid<'Msg> = actor.Pid
 #else
     let pid (actor: Actor<'Msg>) : obj = actor.Pid
 #endif

--- a/src/Fable.Actor/Fable.Actor.fsproj
+++ b/src/Fable.Actor/Fable.Actor.fsproj
@@ -22,7 +22,7 @@
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Fable.Beam" Version="5.0.0-rc.22" />
-    <PackageReference Include="Fable.Core" Version="5.0.0-rc.1" />
+    <PackageReference Include="Fable.Beam" Version="5.0.0-rc.27" />
+    <PackageReference Include="Fable.Core" Version="5.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Fable.Actor/Platform.fs
+++ b/src/Fable.Actor/Platform.fs
@@ -22,7 +22,7 @@ let private atomNormal: Atom = Erlang.binaryToAtom "normal"
 // Process helpers (use Fable.Beam.Erlang with actor-specific atoms)
 // ============================================================================
 
-let killProcess (pid: Pid) : unit = Erlang.exitPid pid atomKill
+let killProcess (pid: Pid<'Msg>) : unit = Erlang.exitPid pid atomKill
 let exitNormal () : unit = Erlang.exit atomNormal
 let trapExits () : unit = Erlang.trapExit () |> ignore
 let formatReason (reason: obj) : string = Erlang.formatTerm reason
@@ -36,7 +36,7 @@ let formatReason (reason: obj) : string = Erlang.formatTerm reason
 type InternalMsg =
     | [<CompiledName("fable_actor_msg")>] ActorMsg of payload: obj
     | [<CompiledName("fable_actor_timer")>] ActorTimer of ref: obj * callback: (obj -> unit)
-    | [<CompiledName("EXIT")>] Exit of pid: Pid * reason: obj
+    | [<CompiledName("EXIT")>] Exit of pid: Pid<obj> * reason: obj
 
 // ============================================================================
 // Message passing
@@ -44,11 +44,11 @@ type InternalMsg =
 
 /// Send a tagged user message: Pid ! {fable_actor_msg, Msg}
 [<Emit("$0 ! {fable_actor_msg, $1}, ok")>]
-let sendMsg (pid: Pid) (msg: obj) : unit = nativeOnly
+let sendMsg (pid: Pid<'Msg>) (msg: 'Msg) : unit = nativeOnly
 
 /// Send a tagged reply: Pid ! {fable_actor_reply, Ref, Value}
 [<Emit("$0 ! {fable_actor_reply, $1, $2}, ok")>]
-let sendReply (pid: Pid) (ref: Ref) (value: obj) : unit = nativeOnly
+let sendReply (pid: Pid<'Caller>) (ref: Ref<'Reply>) (value: 'Reply) : unit = nativeOnly
 
 /// CPS receive: blocks until a user message arrives.
 /// Dispatches timer callbacks and EXIT signals transparently.
@@ -71,12 +71,12 @@ let rec receiveMsg (cont: obj -> unit) : unit =
 /// Blocking selective receive for a reply matching a specific ref.
 /// Uses emitErlExpr to preserve Erlang's bound-variable semantics —
 /// only the message with the matching ref is consumed from the mailbox.
-let recvReply (ref: Ref) : obj =
+let recvReply (ref: Ref<'Reply>) : 'Reply =
     emitErlExpr ref "receive {fable_actor_reply, $0, FableReply} -> FableReply end"
 
 /// Selective receive for a reply with timeout.
 /// Returns Some(reply) or None on timeout.
-let recvReplyWithTimeout (ref: Ref) (timeout: int) : obj option =
+let recvReplyWithTimeout (ref: Ref<'Reply>) (timeout: int) : 'Reply option =
     emitErlExpr (ref, timeout) "receive {fable_actor_reply, $0, FableReply} -> {some, FableReply} after $1 -> undefined end"
 
 // ============================================================================
@@ -93,14 +93,18 @@ let isChildExited (msg: obj) : bool = nativeOnly
 type private TimerControl = | [<CompiledName("cancel")>] Cancel
 
 /// Schedule a callback after ms milliseconds.
-/// Returns the timer process pid for cancellation.
-let timerSchedule (ms: int) (callback: unit -> unit) : Pid =
-    Erlang.spawn (fun () ->
-        match Erlang.receive<TimerControl> ms with
-        | Some Cancel -> ()
-        | None -> callback ())
+/// Returns the timer process pid (boxed) for cancellation.
+let timerSchedule (ms: int) (callback: unit -> unit) : obj =
+    let pid: Pid<TimerControl> =
+        Erlang.spawn (fun () ->
+            match Erlang.receive<TimerControl> ms with
+            | Some Cancel -> ()
+            | None -> callback ())
+
+    box pid
 
 /// Cancel a scheduled timer by sending the cancel atom to its process.
-let timerCancel (timer: Pid) : unit = Erlang.send timer (box Cancel)
+let timerCancel (timer: obj) : unit =
+    Erlang.send (unbox<Pid<TimerControl>> timer) Cancel
 
 #endif

--- a/test/Test.fsproj
+++ b/test/Test.fsproj
@@ -12,6 +12,6 @@
     <ProjectReference Include="../src/Fable.Actor/Fable.Actor.fsproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Fable.Core" Version="5.0.0-rc.1" />
+    <PackageReference Include="Fable.Core" Version="5.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

- Bump `Fable.Beam` 5.0.0-rc.22 → **5.0.0-rc.27** (breaking: `Pid` and `Ref` are now generic — `Pid<'Msg>`, `Ref<'Tag>`).
- Bump Fable CLI/Core/Python to **5.0.0** stable and `Fable.Beam.Cowboy` to 5.0.0-rc.23.
- Adopt typed handles end-to-end: `Actor<'Msg>.Pid : Pid<'Msg>`, `sendMsg`/`recvReply` propagate `'Msg`/`'Reply`, and the `unbox` casts in `call`/`callWithTimeout` are eliminated. Only opaque protocol pids (child-exit signal pid, reply caller pid) remain `Pid<obj>`.
- Drop `-r` from the `format` recipe in the justfile — fantomas 7 recurses by default and rejects the flag.

### Public API impact

`Actor<'Msg>.Pid` and `Actor.pid` now return `Pid<'Msg>` instead of the untyped `Pid`. `Actor.send`, `Post`, and `call` are now type-checked against the actor's message type at the platform layer.

## Test plan

- [x] `dotnet build src/Fable.Actor` — 0 warnings/errors
- [x] `just build` — Fable→BEAM compiles cleanly
- [x] `just test` — 21/21 BEAM tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)