### PR TITLE
refactor: typed Erlang.receive in Platform.fs + Fable 5.2

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "fable": {
-      "version": "5.1.0",
+      "version": "5.2.0",
       "commands": [
         "fable"
       ],

--- a/src/Fable.Actor/Platform.fs
+++ b/src/Fable.Actor/Platform.fs
@@ -23,7 +23,6 @@ let private atomNormal: Atom = Erlang.binaryToAtom "normal"
 // ============================================================================
 
 let killProcess (pid: Pid<'Msg>) : unit = Erlang.exitPid pid atomKill
-let exitNormal () : unit = Erlang.exit atomNormal
 let trapExits () : unit = Erlang.trapExit () |> ignore
 let formatReason (reason: obj) : string = Erlang.formatTerm reason
 
@@ -32,10 +31,11 @@ let formatReason (reason: obj) : string = Erlang.formatTerm reason
 // ============================================================================
 
 /// DU mapping the tagged-tuple envelope used on the wire.
-/// Each case's CompiledName matches the Erlang atom tag.
+/// Each case's CompiledName matches the Erlang atom tag, so a typed
+/// `Erlang.receive<InternalMsg>()` compiles to the selective receive
+/// `receive {fable_actor_msg, ...}; {'EXIT', ...} end`.
 type InternalMsg =
     | [<CompiledName("fable_actor_msg")>] ActorMsg of payload: obj
-    | [<CompiledName("fable_actor_timer")>] ActorTimer of ref: obj * callback: (obj -> unit)
     | [<CompiledName("EXIT")>] Exit of pid: Pid<obj> * reason: obj
 
 // ============================================================================
@@ -50,21 +50,11 @@ let sendMsg (pid: Pid<'Msg>) (msg: 'Msg) : unit = nativeOnly
 [<Emit("$0 ! {fable_actor_reply, $1, $2}, ok")>]
 let sendReply (pid: Pid<'Caller>) (ref: Ref<'Reply>) (value: 'Reply) : unit = nativeOnly
 
-/// CPS receive: blocks until a user message arrives.
-/// Dispatches timer callbacks and EXIT signals transparently.
-/// Uses emitErlExpr for the blocking receive to avoid overload resolution
-/// issues with Erlang.receive<'T>() vs Erlang.receive<'T>(timeout).
+/// CPS receive: blocks until a user message arrives, passing EXIT signals
+/// through transparently as ChildExited (a normal exit is ignored).
 let rec receiveMsg (cont: obj -> unit) : unit =
-    let msg: InternalMsg =
-        emitErlExpr
-            ()
-            "receive {fable_actor_msg, P__} -> {fable_actor_msg, P__}; {fable_actor_timer, R__, C__} -> {fable_actor_timer, R__, C__}; {'EXIT', P__, R__} -> {'EXIT', P__, R__} end"
-
-    match msg with
+    match Erlang.receive<InternalMsg> () with
     | ActorMsg payload -> cont payload
-    | ActorTimer(_, callback) ->
-        callback (box ())
-        receiveMsg cont
     | Exit(_, reason) when Erlang.exactEquals reason atomNormal -> receiveMsg cont
     | Exit(pid, reason) -> cont (box ({ Pid = box pid; Reason = reason }: ChildExited))
 


### PR DESCRIPTION
## Summary

Now that Fable v5 and Fable.Beam rc.32 are out, the BEAM platform layer can lean on Fable.Core's typed `BeamInterop.Erlang.receive<'T>()` and shed a hand-written Erlang `receive` string plus some dead code. Also bumps the Fable tool to 5.2.0.

### Platform.fs simplification
- **`receiveMsg` uses `Erlang.receive<InternalMsg>()`** instead of an `emitErlExpr` literal. The `InternalMsg` DU cases already carry `CompiledName`s matching the wire atoms (`fable_actor_msg`, `EXIT`), so the compiler generates the same selective receive — and the overload-resolution workaround comment goes away.
- **Removed the dead `ActorTimer` / `fable_actor_timer` case.** Nothing ever sends that message — `timerSchedule` spawns a process that invokes the callback directly — so the DU case and its receive clause were vestigial. The generated `receive` now has two clauses instead of three.
- **Removed the dead `exitNormal` helper** (exported but never called).

### Tooling
- **Fable tool 5.1.0 → 5.2.0** (`.config/dotnet-tools.json`).

## What still needs emits (intentionally kept)

- `recvReply` / `recvReplyWithTimeout` — selective receive **bound to a runtime `ref` value**; `Erlang.receive<'T>()` matches by DU tag only and can't express this.
- `sendMsg` / `sendReply` — small typed tagged-tuple sends; converting to DU envelopes would need pid phantom-type casts and add types purely for sending, so they're clearer as-is.
- `isChildExited` — domain-specific map-shape guard with no Fable.Beam equivalent.

## Verification

- `dotnet build src/Fable.Actor` — clean (0 warnings/errors)
- Recompiled to BEAM and diffed `platform.erl` against an rc.32 baseline: only the three intended removals; logic otherwise identical.
- `just test-beam` — **21/21 pass** (on Fable 5.2.0)
- `just test-python` — **21/21 pass** (on Fable 5.2.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)