### PR TITLE
refactor: express wire envelopes via InternalMsg DU instead of Emits

### DIFF
--- a/src/Fable.Actor/Platform.fs
+++ b/src/Fable.Actor/Platform.fs
@@ -36,25 +36,29 @@ let formatReason (reason: obj) : string = Erlang.formatTerm reason
 /// `receive {fable_actor_msg, ...}; {'EXIT', ...} end`.
 type InternalMsg =
     | [<CompiledName("fable_actor_msg")>] ActorMsg of payload: obj
+    | [<CompiledName("fable_actor_reply")>] Reply of ref: Ref<obj> * value: obj
     | [<CompiledName("EXIT")>] Exit of pid: Pid<obj> * reason: obj
 
 // ============================================================================
 // Message passing
 // ============================================================================
 
-/// Send a tagged user message: Pid ! {fable_actor_msg, Msg}
-[<Emit("$0 ! {fable_actor_msg, $1}, ok")>]
-let sendMsg (pid: Pid<'Msg>) (msg: 'Msg) : unit = nativeOnly
+/// Send a tagged user message: Pid ! {fable_actor_msg, Msg}.
+/// The envelope tag comes from InternalMsg.ActorMsg's CompiledName.
+let sendMsg (pid: Pid<'Msg>) (msg: 'Msg) : unit =
+    Erlang.send (unbox<Pid<InternalMsg>> pid) (ActorMsg(box msg))
 
-/// Send a tagged reply: Pid ! {fable_actor_reply, Ref, Value}
-[<Emit("$0 ! {fable_actor_reply, $1, $2}, ok")>]
-let sendReply (pid: Pid<'Caller>) (ref: Ref<'Reply>) (value: 'Reply) : unit = nativeOnly
+/// Send a tagged reply: Pid ! {fable_actor_reply, Ref, Value}.
+/// The envelope tag comes from InternalMsg.Reply's CompiledName.
+let sendReply (pid: Pid<'Caller>) (ref: Ref<'Reply>) (value: 'Reply) : unit =
+    Erlang.send (unbox<Pid<InternalMsg>> pid) (Reply(unbox<Ref<obj>> ref, box value))
 
 /// CPS receive: blocks until a user message arrives, passing EXIT signals
 /// through transparently as ChildExited (a normal exit is ignored).
 let rec receiveMsg (cont: obj -> unit) : unit =
     match Erlang.receive<InternalMsg> () with
     | ActorMsg payload -> cont payload
+    | Reply _ -> receiveMsg cont // stray reply (ref already timed out); drop and keep waiting
     | Exit(_, reason) when Erlang.exactEquals reason atomNormal -> receiveMsg cont
     | Exit(pid, reason) -> cont (box ({ Pid = box pid; Reason = reason }: ChildExited))
 


### PR DESCRIPTION
## What

Replaces the two hand-written wire-protocol `Emit` strings in `Platform.fs` (`sendMsg`, `sendReply`) with `Erlang.send` over the typed `InternalMsg` DU.

- Adds a `Reply` case to `InternalMsg` (`[<CompiledName("fable_actor_reply")>]`) so the reply envelope is produced from the DU tag — same mechanism already used for `ActorMsg`/`Exit`.
- `receiveMsg` gains a `| Reply _ -> receiveMsg cont` arm to drop a stray reply left by a timed-out ref and keep waiting (required now that `Reply` is a DU case).

The generated Erlang is byte-identical to the previous Emits:

```erlang
send_msg(Pid, Msg)          -> Pid ! {fable_actor_msg, Msg}
send_reply(Pid, Ref, Value) -> Pid ! {fable_actor_reply, Ref, Value}
```

(The old Emits had a cosmetic trailing `, ok` whose value was unused — `unit` in F#.)

## Why

The `fable_actor_*` envelope is Fable.Actor's private wire protocol, not an OTP/BIF semantic, so it stays in this library rather than moving to Fable.Beam. Expressing it through the typed DU removes two string Emits and keeps the protocol in one place. **No Fable.Beam changes.**

`recvReply*` and `isChildExited` intentionally remain Actor-local Emits — they encode ref-correlated selective receive and a record shape-check that have no clean typed Fable.Beam primitive yet.

## Verification

- `just build` — Fable → Erlang → rebar3 compiles clean (caught a `box`→`unbox` and a non-exhaustive match the .NET build can't, since the code is behind `#if FABLE_COMPILER_BEAM`).
- `just test-beam` — **21/21 tests pass**, including `actor_call_with_timeout_success` / `actor_call_with_timeout_expires`, which exercise the `sendReply`/`recvReply` round-trip and the timed-out-ref path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)