### PR TITLE
feat: loop/resource CE members + Async bridge for actor { }

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,6 @@ name: Fable.Actor
 
 All notable changes to this project will be documented in this file.
 
-## 5.0.0-rc.10 - 2026-06-14
-
-### 🚀 Features
-
-* Add `For`, `While`, `Using`, and `TryFinally` to the `actor { }` computation expression, so actor bodies can use `for … in` / `while` loops, `use` bindings, and `try/finally`. Implemented on both the BEAM (CPS) and non-BEAM (`async`-delegating) branches.
-* Bridge `Async` into `actor { }` on BEAM: `do!`/`let!` of an `Async<'T>` now works inside an actor body (runs synchronously via `Async.RunSynchronously`, which on BEAM is just the erased callback chain). Unblocks libraries like Fable.Reactive whose observer/disposable methods return `Async`.
-
-### 📝 Notes
-
-* BEAM `TryFinally` captures the body's result and runs the compensation before invoking the continuation, so cleanup happens when the body completes — not after subsequent steps. The compensation runs exactly once on both normal and exceptional exit. Downstream callers should note the bridged `Async` runs to completion synchronously on BEAM (concurrency comes from spawning actors, not from `Async`).
-
 ## 5.0.0-rc.9 - 2026-04-25
 
 ### 🏗️ Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ name: Fable.Actor
 
 All notable changes to this project will be documented in this file.
 
+## 5.0.0-rc.10 - 2026-06-14
+
+### 🚀 Features
+
+* Add `For`, `While`, `Using`, and `TryFinally` to the `actor { }` computation expression, so actor bodies can use `for … in` / `while` loops, `use` bindings, and `try/finally`. Implemented on both the BEAM (CPS) and non-BEAM (`async`-delegating) branches.
+* Bridge `Async` into `actor { }` on BEAM: `do!`/`let!` of an `Async<'T>` now works inside an actor body (runs synchronously via `Async.RunSynchronously`, which on BEAM is just the erased callback chain). Unblocks libraries like Fable.Reactive whose observer/disposable methods return `Async`.
+
+### 📝 Notes
+
+* BEAM `TryFinally` captures the body's result and runs the compensation before invoking the continuation, so cleanup happens when the body completes — not after subsequent steps. The compensation runs exactly once on both normal and exceptional exit. Downstream callers should note the bridged `Async` runs to completion synchronously on BEAM (concurrency comes from spawning actors, not from `Async`).
+
 ## 5.0.0-rc.9 - 2026-04-25
 
 ### 🏗️ Breaking changes

--- a/src/Fable.Actor/Actor.fs
+++ b/src/Fable.Actor/Actor.fs
@@ -56,6 +56,50 @@ type ActorBuilder() =
                     (handler ex).Run cont
     }
 
+    /// CPS try/finally. BEAM ops invoke their continuation synchronously, so we
+    /// capture the body's result via an inner continuation, run the compensation,
+    /// and only then call the outer continuation — otherwise the compensation
+    /// would run *after* the rest of the actor body, not when the body completes.
+    /// The compensation runs exactly once, on both normal and exceptional exit.
+    member _.TryFinally(body: ActorOp<'T>, compensation: unit -> unit) : ActorOp<'T> = {
+        Run =
+            fun cont ->
+                let mutable result = Unchecked.defaultof<'T>
+
+                (try
+                    body.Run(fun value -> result <- value)
+                 with _ ->
+                     compensation ()
+                     reraise ())
+
+                compensation ()
+                cont result
+    }
+
+    member this.Using(resource: 'a :> System.IDisposable, body: 'a -> ActorOp<'T>) : ActorOp<'T> =
+        this.TryFinally(body resource, (fun () -> resource.Dispose()))
+
+    member _.While(guard: unit -> bool, body: ActorOp<unit>) : ActorOp<unit> = {
+        Run =
+            fun cont ->
+                let rec loop () =
+                    if guard () then body.Run(fun () -> loop ()) else cont ()
+
+                loop ()
+    }
+
+    member this.For(items: seq<'T>, body: 'T -> ActorOp<unit>) : ActorOp<unit> =
+        this.Using(items.GetEnumerator(), fun enum -> this.While((fun () -> enum.MoveNext()), this.Delay(fun () -> body enum.Current)))
+
+    /// Bridge an Async into the actor CE. On BEAM, Async is erased to synchronous
+    /// callbacks (there is no async scheduler — concurrency comes from actors), so
+    /// running it to completion via Async.RunSynchronously simply executes the
+    /// callback chain the async already is. This makes `do! someAsyncCall` work
+    /// inside actor { }. BEAM-only: on other targets ActorOp = Async natively.
+    member _.Bind(op: Async<'T>, f: 'T -> ActorOp<'U>) : ActorOp<'U> = {
+        Run = fun cont -> (f (Async.RunSynchronously op)).Run cont
+    }
+
 #else
 
 // === Non-BEAM: MailboxProcessor-based ===
@@ -86,6 +130,13 @@ type ActorBuilder() =
         async.Combine(first, async.Delay(fun () -> second))
 
     member _.TryWith(body: Async<'T>, handler: exn -> Async<'T>) : Async<'T> = async.TryWith(body, handler)
+
+    member _.TryFinally(body: Async<'T>, compensation: unit -> unit) : Async<'T> = async.TryFinally(body, compensation)
+
+    member _.Using(resource: 'a :> System.IDisposable, body: 'a -> Async<'T>) : Async<'T> = async.Using(resource, body)
+
+    member _.While(guard: unit -> bool, body: Async<unit>) : Async<unit> = async.While(guard, body)
+    member _.For(items: seq<'T>, body: 'T -> Async<unit>) : Async<unit> = async.For(items, body)
 
 #endif
 

--- a/src/Fable.Actor/Actor.fs
+++ b/src/Fable.Actor/Actor.fs
@@ -92,10 +92,11 @@ type ActorBuilder() =
         this.Using(items.GetEnumerator(), fun enum -> this.While((fun () -> enum.MoveNext()), this.Delay(fun () -> body enum.Current)))
 
     /// Bridge an Async into the actor CE. On BEAM, Async is erased to synchronous
-    /// callbacks (there is no async scheduler — concurrency comes from actors), so
-    /// running it to completion via Async.RunSynchronously simply executes the
-    /// callback chain the async already is. This makes `do! someAsyncCall` work
-    /// inside actor { }. BEAM-only: on other targets ActorOp = Async natively.
+    /// callbacks (there is no async scheduler — concurrency comes from spawning
+    /// actors, and Async.Parallel, not from sequential Async), so running it to
+    /// completion via Async.RunSynchronously simply executes the callback chain the
+    /// async already is — inline in this process. This makes `do! someAsyncCall`
+    /// work inside actor { }. BEAM-only: on other targets ActorOp = Async natively.
     member _.Bind(op: Async<'T>, f: 'T -> ActorOp<'U>) : ActorOp<'U> = {
         Run = fun cont -> (f (Async.RunSynchronously op)).Run cont
     }

--- a/test/ActorTest.fs
+++ b/test/ActorTest.fs
@@ -12,8 +12,7 @@ open Fable.Actor.TestUtils
 /// An actor that does nothing should not crash.
 let actor_empty_test () =
     actor {
-        let _a: Actor<string> =
-            Actor.spawn (fun _inbox -> actor { return () })
+        let _a: Actor<string> = Actor.spawn (fun _inbox -> actor { return () })
 
         do! sleep 10
         shouldBeTrue true
@@ -293,9 +292,14 @@ let actor_schedule_test () =
                     rc.Reply count
                     Continue count)
 
-        Actor.schedule 10 (fun () -> Actor.cast ticker Tick) |> ignore
-        Actor.schedule 20 (fun () -> Actor.cast ticker Tick) |> ignore
-        Actor.schedule 30 (fun () -> Actor.cast ticker Tick) |> ignore
+        Actor.schedule 10 (fun () -> Actor.cast ticker Tick)
+        |> ignore
+
+        Actor.schedule 20 (fun () -> Actor.cast ticker Tick)
+        |> ignore
+
+        Actor.schedule 30 (fun () -> Actor.cast ticker Tick)
+        |> ignore
 
         do! sleep 100
 
@@ -352,7 +356,9 @@ let reporter initial =
     Actor.start initial (fun state (msg, rc) ->
         match msg with
         | Some v -> Continue v
-        | None -> rc.Reply state; Continue state)
+        | None ->
+            rc.Reply state
+            Continue state)
 
 /// spawnSupervised restarts a crashed child when strategy says Restart.
 let actor_supervised_restart_test () =
@@ -428,7 +434,9 @@ let actor_supervised_stop_test () =
                         match Actor.tryAsChildExited msg with
                         | Some exited ->
                             let restarted = Actor.handleChildExit inbox child exited
-                            if not restarted then Actor.cast flag (Some true)
+
+                            if not restarted then
+                                Actor.cast flag (Some true)
                         | None -> ()
 
                         return! loop ()
@@ -476,7 +484,9 @@ let actor_stop_abnormal_test () =
 
                         match Actor.tryAsChildExited msg with
                         | Some exited ->
-                            Actor.handleChildExit inbox stoppingChild exited |> ignore
+                            Actor.handleChildExit inbox stoppingChild exited
+                            |> ignore
+
                             Actor.cast flag (Some true)
                         | None -> ()
 
@@ -633,6 +643,103 @@ let actor_call_with_timeout_expires_test () =
             timedOut <- true
 
         shouldBeTrue timedOut
+    }
+
+// ============================================================================
+// computation-expression control-flow tests (for/while/use/try-finally)
+// ============================================================================
+
+/// A for..in loop over a list runs the body for each element, in order.
+let actor_for_loop_test () =
+    actor {
+        let mutable acc = []
+
+        for x in [ 1; 2; 3 ] do
+            do! sleep 1
+            acc <- acc @ [ x * 10 ]
+
+        shouldEqual [ 10; 20; 30 ] acc
+    }
+
+/// A while loop repeats the body until the guard is false.
+let actor_while_loop_test () =
+    actor {
+        let mutable i = 0
+        let mutable sum = 0
+
+        while i < 5 do
+            do! sleep 1
+            sum <- sum + i
+            i <- i + 1
+
+        shouldEqual 10 sum
+    }
+
+/// A use binding disposes the resource when the scope ends.
+let actor_use_dispose_test () =
+    actor {
+        let mutable disposed = false
+
+        do!
+            actor {
+                use _r =
+                    { new System.IDisposable with
+                        member _.Dispose() = disposed <- true
+                    }
+
+                do! sleep 1
+            }
+
+        shouldBeTrue disposed
+    }
+
+/// try/finally runs the compensation on normal completion.
+let actor_try_finally_normal_test () =
+    actor {
+        let mutable cleaned = false
+
+        do!
+            actor {
+                try
+                    do! sleep 1
+                finally
+                    cleaned <- true
+            }
+
+        shouldBeTrue cleaned
+    }
+
+/// try/finally runs the compensation when the body throws, and re-raises.
+let actor_try_finally_exn_test () =
+    actor {
+        let mutable cleaned = false
+        let mutable caught = false
+
+        try
+            do!
+                actor {
+                    try
+                        do! sleep 1
+                        failwith "boom"
+                    finally
+                        cleaned <- true
+                }
+        with _ ->
+            caught <- true
+
+        shouldBeTrue cleaned
+        shouldBeTrue caught
+    }
+
+/// do!/let! of an Async inside an actor body observably runs and yields a value.
+/// On BEAM this exercises the Async -> ActorOp bridge (Async.RunSynchronously).
+let actor_async_bind_test () =
+    actor {
+        let mutable ran = false
+        do! async { ran <- true }
+        let! v = async { return 42 }
+        shouldBeTrue ran
+        shouldEqual 42 v
     }
 
 // ============================================================================

--- a/test/Program.fs
+++ b/test/Program.fs
@@ -58,7 +58,44 @@ let mainAsync =
         // kill
         let! r21 = runTest "actor_kill" actor_kill_test
 
-        let results = [ r1; r2; r3; r4; r5; r6; r7; r8; r9; r10; r11; r12; r13; r14; r15; r16; r17; r18; r19; r20; r21 ]
+        // CE control flow (for/while/use/try-finally) + async bridge
+        let! r22 = runTest "actor_for_loop" actor_for_loop_test
+        let! r23 = runTest "actor_while_loop" actor_while_loop_test
+        let! r24 = runTest "actor_use_dispose" actor_use_dispose_test
+        let! r25 = runTest "actor_try_finally_normal" actor_try_finally_normal_test
+        let! r26 = runTest "actor_try_finally_exn" actor_try_finally_exn_test
+        let! r27 = runTest "actor_async_bind" actor_async_bind_test
+
+        let results = [
+            r1
+            r2
+            r3
+            r4
+            r5
+            r6
+            r7
+            r8
+            r9
+            r10
+            r11
+            r12
+            r13
+            r14
+            r15
+            r16
+            r17
+            r18
+            r19
+            r20
+            r21
+            r22
+            r23
+            r24
+            r25
+            r26
+            r27
+        ]
+
         let passed = results |> List.filter id |> List.length
         let total = results.Length
         printfn ""


### PR DESCRIPTION
## Summary

Upstream work to unblock the **Fable.Reactive** BEAM port, which needs to switch its `Actor.spawn` bodies from `async { }` to `actor { }`. Those bodies use `for … in` loops and `do!` of `Async<unit>` calls (`obv.OnNextAsync x`, `disp.DisposeAsync()`) that the current `ActorBuilder` can't express.

Two additive, backward-compatible changes to `src/Fable.Actor/Actor.fs`:

### 1. CE control flow: `For` / `While` / `Using` / `TryFinally`
Added to **both** `ActorBuilder` branches so actor bodies can use `for … in` / `while` loops, `use` bindings, and `try/finally`.
- **Non-BEAM**: delegate to `async.For/While/Using/TryFinally`.
- **BEAM (CPS)**: implemented directly — `For` builds on `While` + `Using` over the enumerator.

### 2. Async → ActorOp bridge (BEAM-only)
A `Bind(Async<'T>, 'T -> ActorOp<'U>)` overload that runs the async to completion via `Async.RunSynchronously`, so `do! someAsyncCall` works inside `actor { }`. On BEAM, `Async` is erased to synchronous callbacks (concurrency comes from spawning actors, not `Async`), so this just runs the callback chain the async already is — it loses nothing. BEAM-only: on other targets `ActorOp = Async`, so the overload already exists and a duplicate would be ambiguous.

## Caveat for downstream callers
BEAM `TryFinally` captures the body's result via an inner continuation and runs the compensation **before** the outer continuation, so cleanup happens when the body completes (not after subsequent steps) and runs exactly once on both normal and exceptional exit. This relies on BEAM ops being synchronous-blocking CPS (documented in a code comment).

## Tests
6 new cross-target tests: `for` loop, `while` loop, `use`/dispose, `try/finally` (normal + exceptional), and `do!`/`let!` of `Async` inside an actor body.

**27/27 pass on all three targets** (`just test` → .NET, Python, BEAM). The BEAM `actor_async_bind` test confirms the `Async.RunSynchronously` overload resolves and executes.

## Other
- Changelog bumped to `5.0.0-rc.10` for Fable.Reactive to depend on.
- Formatted with `dotnet fantomas`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)