### PR TITLE
feat: add Actor.callAsync — request-reply returning Async<'Reply>

### DIFF
--- a/src/Fable.Actor/Actor.fs
+++ b/src/Fable.Actor/Actor.fs
@@ -206,6 +206,16 @@ module Actor =
                 cont (recvReply ref)
     }
 
+    /// Send a message and await a reply as an Async (usable from async { } contexts).
+    /// BEAM processes block natively, so the CPS Run continuation fires synchronously
+    /// once the reply arrives — capture it and return.
+    let callAsync (actor: Actor<'Msg * ReplyChannel<'Reply>>) (msg: 'Msg) : Async<'Reply> =
+        async {
+            let mutable result = Unchecked.defaultof<'Reply>
+            (call actor msg).Run(fun reply -> result <- reply)
+            return result
+        }
+
     /// Send a message and await a reply with a timeout in milliseconds.
     /// Raises TimeoutException if no reply is received within the timeout.
     let callWithTimeout (timeout: int) (actor: Actor<'Msg * ReplyChannel<'Reply>>) (msg: 'Msg) : ActorOp<'Reply> = {
@@ -303,6 +313,10 @@ module Actor =
 
             return reply
         }
+
+    /// Send a message and await a reply as an Async (usable from async { } contexts).
+    /// On non-BEAM targets ActorOp = Async, so this is a direct alias for call.
+    let callAsync (target: Actor<'Msg * ReplyChannel<'Reply>>) (msg: 'Msg) : Async<'Reply> = call target msg
 
     /// Send a message and await a reply with a timeout in milliseconds.
     /// Raises TimeoutException if no reply is received within the timeout.

--- a/test/ActorTest.fs
+++ b/test/ActorTest.fs
@@ -743,6 +743,39 @@ let actor_async_bind_test () =
     }
 
 // ============================================================================
+// callAsync tests
+// ============================================================================
+
+/// callAsync awaits a reply as an Async, usable from inside an async { } block.
+/// This is the regression target for Fable.Reactive's mapActor: on BEAM, call is
+/// CPS and cannot be let!-bound in async { }, but callAsync can. The caller (this
+/// process) and server (a distinct process from Actor.start) must not deadlock.
+let actor_call_async_test () =
+    actor {
+        let server =
+            Actor.start 0 (fun count (msg, rc) ->
+                match msg with
+                | Increment -> Continue(count + 1)
+                | Decrement -> Continue(count - 1)
+                | GetCount ->
+                    rc.Reply count
+                    Continue count)
+
+        Actor.cast server Increment
+        Actor.cast server Increment
+        do! sleep 10
+
+        // The real regression: let! callAsync from inside an async { } block.
+        let! count =
+            async {
+                let! c = Actor.callAsync server GetCount
+                return c
+            }
+
+        shouldEqual 2 count
+    }
+
+// ============================================================================
 // kill tests
 // ============================================================================
 

--- a/test/Program.fs
+++ b/test/Program.fs
@@ -66,6 +66,9 @@ let mainAsync =
         let! r26 = runTest "actor_try_finally_exn" actor_try_finally_exn_test
         let! r27 = runTest "actor_async_bind" actor_async_bind_test
 
+        // callAsync
+        let! r28 = runTest "actor_call_async" actor_call_async_test
+
         let results = [
             r1
             r2
@@ -94,6 +97,7 @@ let mainAsync =
             r25
             r26
             r27
+            r28
         ]
 
         let passed = results |> List.filter id |> List.length


### PR DESCRIPTION
## Summary

Adds **`Actor.callAsync`** — a request-reply that returns `Async<'Reply>` so it can be `let!`-bound from inside an `async { }` context on all targets. This is the reverse companion to the rc.10 Async→ActorOp bridge:

- rc.10 let you `do!` an `Async` inside `actor { }`.
- `callAsync` lets you `let!` an actor call inside `async { }`.

Downstream, Fable.Reactive's `mapActor` operator does `let! result = Actor.call actor x` inside an `async { }` observer, which fails to compile on BEAM because `call` returns the CPS `ActorOp`, not `Async`. `callAsync` fixes that.

## Implementation (`src/Fable.Actor/Actor.fs`)

Added immediately after `call` in both platform branches, mirroring the `call`/`callWithTimeout` ordering so the branches stay structurally in sync:

- **BEAM** (`#if FABLE_COMPILER_BEAM`): wraps the CPS `call` in an `async`, runs its `Run` continuation, and returns the captured reply. BEAM processes block natively, so the continuation fires synchronously once the reply arrives.
- **non-BEAM** (`#else`): `ActorOp = Async`, so `callAsync` is a direct alias for `call`.

Purely additive and backward-compatible — `call`/`callWithTimeout` and all existing tests are untouched.

## Tests

Adds `actor_call_async_test` (`test/ActorTest.fs`, registered in `Program.fs`): from inside an `async { }` block it does `let! reply = Actor.callAsync server GetCount` against a counter server started with `Actor.start`, and asserts the reply. The server is a distinct process from the caller, so `callAsync` does not deadlock on BEAM.

`just test` — all three targets green:
- .NET: 28/28
- Python: 28/28
- BEAM: 28/28

Formatted with `dotnet fantomas src test` (max line length 120). Changelog bump intentionally omitted (handled automatically at release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)